### PR TITLE
Fixed PowerShell tasks where parameters might include spaces

### DIFF
--- a/Pipelines/Templates/build-Solution.yml
+++ b/Pipelines/Templates/build-Solution.yml
@@ -32,14 +32,14 @@ steps:
 # Before we committed changes, we formatted all json files for readability in source control.  This breaks solution package, so we need to flatten them before packing   
 - pwsh: |
     #When we unpack the solution files, we format the json, but it causes solution import failures so we need to flatten the files
-    Get-ChildItem -Path $(Build.SourcesDirectory)\$(RepoName)\$(SolutionName) -Recurse -Filter *.json |
+    Get-ChildItem -Path "$(Build.SourcesDirectory)\$(RepoName)\$(SolutionName)" -Recurse -Filter *.json |
     ForEach-Object {(Get-Content $_.FullName) -join ' ' | Set-Content $_.FullName}
   displayName: 'Flatten JSON files'
   enabled: true
 
 # Use temp exe from PowerShell to pack source files into msapp
 - pwsh: |
-   Get-ChildItem -Path $(Build.SourcesDirectory)\$(RepoName)\$(SolutionName) -Recurse -Filter *_src | 
+   Get-ChildItem -Path "$(Build.SourcesDirectory)\$(RepoName)\$(SolutionName)" -Recurse -Filter *_src | 
    ForEach-Object {     
      $unpackedPath = $_.FullName
      $packedFileName = $unpackedPath.Replace("_msapp_src", ".msapp")

--- a/Pipelines/Templates/export-Solution.yml
+++ b/Pipelines/Templates/export-Solution.yml
@@ -108,7 +108,7 @@ steps:
 
 # Use temp exe from PowerShell to unpack source files into a folder
 - pwsh: |
-   Get-ChildItem -Path $(Build.SourcesDirectory)\${{parameters.Repo}}\${{parameters.SolutionName}} -Recurse -Filter *.msapp | 
+   Get-ChildItem -Path "$(Build.SourcesDirectory)\${{parameters.Repo}}\${{parameters.SolutionName}}" -Recurse -Filter *.msapp | 
    ForEach-Object {
       $unpackedPath = $_.FullName.Replace(".msapp", "_msapp_src")
       $(Pipeline.Workspace)\PipelineUtils\Pipelines\temp-canvas-packager\temp-canvas-packager.exe -unpack $_.FullName $unpackedPath
@@ -122,7 +122,7 @@ steps:
 # This also makes it easier to read changes from one commit to another
 - powershell: |
    Invoke-WebRequest -Uri https://github.com/stedolan/jq/releases/download/jq-1.6/jq-win64.exe -OutFile  jq.exe
-   Get-ChildItem -Path $(Build.SourcesDirectory)\${{parameters.Repo}}\${{parameters.SolutionName}} -Recurse -Filter *.json | 
+   Get-ChildItem -Path "$(Build.SourcesDirectory)\${{parameters.Repo}}\${{parameters.SolutionName}}" -Recurse -Filter *.json | 
    ForEach-Object {
        $formatted = .\jq.exe . $_.FullName
        $formatted | Out-File $_.FullName 


### PR DESCRIPTION
Certain powershell tasks in the templates `Pipelines/Templates/build-Solution.yml` and `Pipelines/Templates/export-Solution.yml` currently fail since some parameters (notably paths generated via variables) might contain spaces.

