### PR TITLE
add sync-pipeline-repo #234

### DIFF
--- a/Pipelines/Templates/sync-pipeline-repo.yml
+++ b/Pipelines/Templates/sync-pipeline-repo.yml
@@ -1,0 +1,50 @@
+# This pipeline gets triggered manually or via an API call.  
+# The pipeline is designed to synchronize a github repository into an Azure DevOps git repositiory.
+# It facilitates:
+# -Synchronization of main branch from source git repository into the Azure DevOps git repository that this pipeline is being run against
+
+# The following variables need to be set when the pipeline is queued to run:
+# Template-repo: The source github repository to be synced intot the Azure DevOps git repository that this pipeline is in.
+
+# The following parameters are required for pipeline to run:
+# BranchToCreate: The name of the new Azure DevOps Branch to create in the Repo above to which we are pulling main branch from Template-repo.
+
+parameters:
+- name: BranchToCreate
+  type: string
+  default: 'update-from-original-repo'
+- name: CommitMessage
+  type: string
+  default: 'update from original repo'
+  
+trigger:
+- none
+
+stages:
+- stage: sync
+  displayName: Sync
+  jobs:
+  - job: syncjob
+    pool:
+      vmImage: 'windows-2019'
+    steps:
+      - checkout: self
+        persistCredentials: true
+      
+        # Configure email/name
+      - script: |
+          git config --global user.email "$(Build.RequestedForEmail)"
+          git config --global user.name "$(Build.RequestedFor)"
+        displayName: 'Set git user info'
+
+        # Add remote and fetch main
+      - script: | 
+          git remote add template-repo $(TEMPLATE-REPO)
+          git fetch template-repo main
+        displayName: 'Fetch main branch from $(TEMPLATE-REPO)'
+
+        # create new branch and push to origin
+      - script: |
+          git checkout -b ${{parameters.BranchToCreate}} template-repo/main
+          git push origin +${{parameters.BranchToCreate}}
+        displayName: 'Push ${{parameters.BranchToCreate}} to AzDO repo'

--- a/Pipelines/sync-pipeline-repo.yml
+++ b/Pipelines/sync-pipeline-repo.yml
@@ -17,8 +17,8 @@ parameters:
   type: string
   default: 'update from original repo'
   
-trigger:
-- none
+trigger: none
+pr: none
 
 stages:
 - stage: sync


### PR DESCRIPTION
added pipeline to sync the github pipeline template repo into an azure project git repo.

pipeline does:
1. add new remote (template repo) to AzDO git repo
1. fetch main from template repo
1. create new branch for AzDO git repo
1. push latest from template repo in new branch to AzDO git repo

From here user will create pull request and merge any changes from template repo into their AzDO repo

closes https://github.com/microsoft/coe-starter-kit/issues/234