### PR TITLE
Fixes microsoft/coe-starter-kit#238

### DIFF
--- a/Pipelines/build-SampleSolution.yml
+++ b/Pipelines/build-SampleSolution.yml
@@ -23,7 +23,7 @@ name: 1.0.$(Date:yyyyMMdd)$(Rev:.r)
 # NOTE: If you want to use different values for these variables, you can remove the variable group and attach them directly to this pipeline. The group specified below is a variable group defined in the Library for the Pipelines
 variables:
 - group: global-variable-group
-- name: SolutionName
+- name: SolutionName # variable Name  (DO NOT CHANGE THIS VALUE) 
   value: 'SampleSolutionName' #Replace with the actual name of the solution you are building. (NOTE: Not the Display Name)
 
 stages:

--- a/Pipelines/build-deploy-SampleSolution.yml
+++ b/Pipelines/build-deploy-SampleSolution.yml
@@ -23,7 +23,7 @@ name: 1.0.$(Date:yyyyMMdd)$(Rev:.r)
 # NOTE: If you want to use different values for these variables, you can remove the variable group and attach them directly to this pipeline. The group specified below is a variable group defined in the Library for the Pipelines
 variables:
 - group: global-variable-group
-- name: SolutionName
+- name: SolutionName # variable Name  (DO NOT CHANGE THIS VALUE) 
   value: 'SampleSolutionName' #Replace with the actual name of the solution you are building. (NOTE: Not the Display Name)
 
 stages:

--- a/Pipelines/deploy-prod-buildcompletion-SampleSolution.yml
+++ b/Pipelines/deploy-prod-buildcompletion-SampleSolution.yml
@@ -10,7 +10,7 @@ resources:
     ref: BranchContainingTheBuildTemplates # If your pipeline templates are in a branch other than the default branch specify the branch here. Otherwise the default branch will be used by default.
     name: RepositoryContainingTheBuildTemplates  # This is the name of the repo in the current project in Azure Devops that has the pipeline templates. If the repo is in a different project you can specify the project and repo using the format ProjectContainingTheBuildTemplates/RepositoryContainingTheBuildTemplates (https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#type)
   pipelines: # The pipelines specify which pipeline this pipeline will trigger off of upon completion. In this case we will run deploy after the build pipeline succeeds
-    - pipeline: buildPipeline
+    - pipeline: buildPipeline # pipeline name (DO NOT CHANGE THIS VALUE) 
       source: build-SampleSolutionName # This is the name of the build pipeline that triggers this deployment pipeline 
       trigger: 
         branches:
@@ -21,7 +21,7 @@ resources:
 # NOTE: If you want to use different values for these variables, you can remove the variable group and attach them directly to this pipeline. The group specified below is a variable group defined in the Library for the Pipelines
 variables:
 - group: global-variable-group
-- name: SolutionName
+- name: SolutionName # variable Name  (DO NOT CHANGE THIS VALUE) 
   value: 'SampleSolutionName' #Replace with the actual name of the solution you are building. (NOTE: Not the Display Name)
 
 stages:

--- a/Pipelines/deploy-prod-pipelineartifact-SampleSolution.yml
+++ b/Pipelines/deploy-prod-pipelineartifact-SampleSolution.yml
@@ -1,0 +1,27 @@
+# Starter template for:
+# Deploying the solution to a validation environment
+# Deployment is triggered by build completion so no trigger or pr should be specified
+trigger:
+  branches:
+    include:
+    # Replace the following with actual branch name(s) in your repo for which you want to trigger a production deployment. The assumption here is that you only want to only trigger on a change to a specific branch rather than a change on any branch which would include your working branch for development.'
+    - main
+pr: none
+resources:
+  repositories:
+  - repository: PipelineRepo  # repository name (DO NOT CHANGE THIS VALUE) 
+    type: git
+    ref: BranchContainingTheBuildTemplates # If your pipeline templates are in a branch other than the default branch specify the branch here. Otherwise the default branch will be used by default.
+    name: RepositoryContainingTheBuildTemplates  # This is the name of the repo in the current project in Azure Devops that has the pipeline templates. If the repo is in a different project you can specify the project and repo using the format ProjectContainingTheBuildTemplates/RepositoryContainingTheBuildTemplates (https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#type)
+  pipelines: # The pipelines specify which pipeline this pipeline will pull artifacts from. In this case we will deploy from the test build's artifacts
+    - pipeline: buildPipeline  # pipeline name (DO NOT CHANGE THIS VALUE) 
+      source: deploy-test-SampleSolution # This is the name of the build pipeline that contains the artifacts to be deployed by this pipeline. NOTE: There must be a successful build for this pipeline available in order to run this pipeline
+
+# NOTE: If you want to use different values for these variables, you can remove the variable group and attach them directly to this pipeline. The group specified below is a variable group defined in the Library for the Pipelines
+variables:
+- group: global-variable-group
+- name: SolutionName # variable Name  (DO NOT CHANGE THIS VALUE) 
+  value: 'SampleSolution' #Replace with the actual name of the solution you are building. (NOTE: Not the Display Name)
+
+stages:
+  - template: Pipelines\Templates\deploy-Solution-To-Environment.yml@PipelineRepo

--- a/Pipelines/deploy-test-buildcompletion-SampleSolution.yml
+++ b/Pipelines/deploy-test-buildcompletion-SampleSolution.yml
@@ -7,21 +7,21 @@ resources:
   repositories:
   - repository: PipelineRepo  # repository name (DO NOT CHANGE THIS VALUE) 
     type: git
-    ref: BranchContainingTheBuildTemplates # If your pipeline templates are in a branch other than the default branch specify the branch here. Otherwise remove this parameter.
-    name: RepositoryContainingTheBuildTemplates  #This is the name of the repo in the current project in Azure Devops that has the pipeline templates. If the repo is in a different project you can specify the project and repo using the format ProjectContainingTheBuildTemplates/RepositoryContainingTheBuildTemplates (https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#type)
+    ref: BranchContainingTheBuildTemplates # If your pipeline templates are in a branch other than the default branch specify the branch here. Otherwise the default branch will be used by default.
+    name: RepositoryContainingTheBuildTemplates  # This is the name of the repo in the current project in Azure Devops that has the pipeline templates. If the repo is in a different project you can specify the project and repo using the format ProjectContainingTheBuildTemplates/RepositoryContainingTheBuildTemplates (https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#type)
   pipelines: # The pipelines specify which pipeline this pipeline will trigger off of upon completion. In this case we will run deploy after the build pipeline succeeds
-    - pipeline: buildPipeline
+    - pipeline: buildPipeline # pipeline name (DO NOT CHANGE THIS VALUE) 
       source: build-SampleSolutionName # This is the name of the build pipeline that triggers this deployment pipeline 
       trigger: 
         branches:
           include: #Include the branches you want to trigger on to deploy to the environment specified in the Pipeline variables. refs/pull/* will run on PR Builds
           # Replace the following with actual branch name(s) in your repo for which you want to trigger a build. The assumption here is that you only want to only trigger on a change to a specific branch rather than a change on any branch which would include your working branch for development.'
-          - refs/pull/*
+          - SampleSolutionName
 
 # NOTE: If you want to use different values for these variables, you can remove the variable group and attach them directly to this pipeline. The group specified below is a variable group defined in the Library for the Pipelines
 variables:
 - group: global-variable-group
-- name: SolutionName
+- name: SolutionName # variable Name  (DO NOT CHANGE THIS VALUE) 
   value: 'SampleSolutionName' #Replace with the actual name of the solution you are building. (NOTE: Not the Display Name)
 
 stages:

--- a/Pipelines/deploy-test-pipelineartifact-SampleSolution.yml
+++ b/Pipelines/deploy-test-pipelineartifact-SampleSolution.yml
@@ -1,0 +1,27 @@
+# Starter template for:
+# Deploying the solution to a validation environment
+# Deployment is triggered by build completion so no trigger or pr should be specified
+trigger:
+  branches:
+    include:
+    # Replace the following with actual branch name(s) in your repo for which you want to trigger a production deployment. The assumption here is that you only want to only trigger on a change to a specific branch rather than a change on any branch which would include your working branch for development.'
+    - SampleSolution
+pr: none
+resources:
+  repositories:
+  - repository: PipelineRepo  # repository name (DO NOT CHANGE THIS VALUE) 
+    type: git
+    ref: BranchContainingTheBuildTemplates # If your pipeline templates are in a branch other than the default branch specify the branch here. Otherwise the default branch will be used by default.
+    name: RepositoryContainingTheBuildTemplates  # This is the name of the repo in the current project in Azure Devops that has the pipeline templates. If the repo is in a different project you can specify the project and repo using the format ProjectContainingTheBuildTemplates/RepositoryContainingTheBuildTemplates (https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#type)
+  pipelines: # The pipelines specify which pipeline this pipeline will pull artifacts from. In this case we will deploy from the test build's artifacts
+    - pipeline: buildPipeline # pipeline name (DO NOT CHANGE THIS VALUE) 
+      source: deploy-validation-SampleSolution # This is the name of the build pipeline that contains the artifacts to be deployed by this pipeline. NOTE: There must be a successful build for this pipeline available in order to run this pipeline
+
+# NOTE: If you want to use different values for these variables, you can remove the variable group and attach them directly to this pipeline. The group specified below is a variable group defined in the Library for the Pipelines
+variables:
+- group: global-variable-group
+- name: SolutionName # variable Name  (DO NOT CHANGE THIS VALUE) 
+  value: 'SampleSolution' #Replace with the actual name of the solution you are building. (NOTE: Not the Display Name)
+
+stages:
+  - template: Pipelines\Templates\deploy-Solution-To-Environment.yml@PipelineRepo

--- a/Pipelines/deploy-validation-buildcompletion-SampleSolution.yml
+++ b/Pipelines/deploy-validation-buildcompletion-SampleSolution.yml
@@ -7,21 +7,21 @@ resources:
   repositories:
   - repository: PipelineRepo  # repository name (DO NOT CHANGE THIS VALUE) 
     type: git
-    ref: BranchContainingTheBuildTemplates # If your pipeline templates are in a branch other than the default branch specify the branch here. Otherwise the default branch will be used by default.
-    name: RepositoryContainingTheBuildTemplates  # This is the name of the repo in the current project in Azure Devops that has the pipeline templates. If the repo is in a different project you can specify the project and repo using the format ProjectContainingTheBuildTemplates/RepositoryContainingTheBuildTemplates (https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#type)
+    ref: BranchContainingTheBuildTemplates # If your pipeline templates are in a branch other than the default branch specify the branch here. Otherwise remove this parameter.
+    name: RepositoryContainingTheBuildTemplates  #This is the name of the repo in the current project in Azure Devops that has the pipeline templates. If the repo is in a different project you can specify the project and repo using the format ProjectContainingTheBuildTemplates/RepositoryContainingTheBuildTemplates (https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#type)
   pipelines: # The pipelines specify which pipeline this pipeline will trigger off of upon completion. In this case we will run deploy after the build pipeline succeeds
-    - pipeline: buildPipeline
+    - pipeline: buildPipeline # pipeline name (DO NOT CHANGE THIS VALUE) 
       source: build-SampleSolutionName # This is the name of the build pipeline that triggers this deployment pipeline 
       trigger: 
         branches:
           include: #Include the branches you want to trigger on to deploy to the environment specified in the Pipeline variables. refs/pull/* will run on PR Builds
           # Replace the following with actual branch name(s) in your repo for which you want to trigger a build. The assumption here is that you only want to only trigger on a change to a specific branch rather than a change on any branch which would include your working branch for development.'
-          - SampleSolutionName
+          - refs/pull/*
 
 # NOTE: If you want to use different values for these variables, you can remove the variable group and attach them directly to this pipeline. The group specified below is a variable group defined in the Library for the Pipelines
 variables:
 - group: global-variable-group
-- name: SolutionName
+- name: SolutionName # variable Name  (DO NOT CHANGE THIS VALUE) 
   value: 'SampleSolutionName' #Replace with the actual name of the solution you are building. (NOTE: Not the Display Name)
 
 stages:

--- a/Pipelines/trigger-SampleSolution.yml
+++ b/Pipelines/trigger-SampleSolution.yml
@@ -20,7 +20,7 @@ name: 1.0.$(Date:yyyyMMdd)$(Rev:.r)
 # NOTE: If you want to use different values for these variables, you can remove the variable group and attach them directly to this pipeline. The group specified below is a variable group defined in the Library for the Pipelines
 variables:
 - group: global-variable-group
-- name: SolutionName
+- name: SolutionName # variable Name  (DO NOT CHANGE THIS VALUE) 
   value: 'SampleSolutionName' #Replace with the actual name of the solution you are building. (NOTE: Not the Display Name)
 
 stages:


### PR DESCRIPTION
Fixes microsoft/coe-starter-kit#238. Updating sample templates for handling pipeline artifact deployment. Also, renamed the old deployment pipelines to distinguish them as buildcompletion vs pipelineartifact. 