### PR TITLE
ALM Accelerator For Advanced Makers 1.0.20210503.1

### DIFF
--- a/Pipelines/delete-unmanaged-solution-and-components.yml
+++ b/Pipelines/delete-unmanaged-solution-and-components.yml
@@ -1,6 +1,8 @@
 # This pipeline gets triggered manually or via an API call.  
 # It is a general purpose automation that allows you to delete or "clean up" an unmanaged solution from a Dataverse environment.
 # It is a destructive action and will remove everything in the solution from the environment.
+# If there are dependencies in other solutions on components in the solution you are trying to clean up / delete, the pipeline will fail.
+# You need to clean up dependencies before running this pipeline.
 
 # The following variables need to be set when the pipeline is queued to run:
 # ServiceConnName
@@ -13,45 +15,88 @@ name: delete-unmanaged-$(SolutionName)-and-components-from-environment
 
 variables:
 - group: global-variable-group
+- name: vmImage
+  value: 'windows-2019'
 
-pool:
-  vmImage: 'windows-2019'
+stages:
+- stage: exportAndDeleteUnmanaged
+  jobs:
+    - job: exportAndDeleteUnmanaged  
+      pool:
+        vmImage: ${{ variables.vmImage }}
+      steps:
+      - checkout: none
 
-steps:
-- checkout: none
+      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@0
+        displayName: 'Power Platform Tool Installer '
 
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@0
-  displayName: 'Power Platform Tool Installer '
+      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.export-solution.PowerPlatformExportSolution@0
+        displayName: 'Export Solution as Managed'
+        inputs:
+          authenticationType: PowerPlatformSPN
+          PowerPlatformSPN: '$(ServiceConnName)'
+          SolutionName: '$(SolutionName)'
+          Managed: true
+          SolutionOutputFile: '$(Pipeline.Workspace)\exported\$(SolutionName).zip'
 
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.export-solution.PowerPlatformExportSolution@0
-  displayName: 'Export Solution as Managed'
-  inputs:
-    authenticationType: PowerPlatformSPN
-    PowerPlatformSPN: '$(ServiceConnName)'
-    SolutionName: '$(SolutionName)'
-    Managed: true
-    SolutionOutputFile: '$(build.binariesdirectory)\$(SolutionName).zip'
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: '$(Pipeline.Workspace)\exported'
+          artifact: 'drop'
+          publishLocation: 'pipeline'
 
-- task: PowerPlatformDeleteSolution@0
-  displayName: 'Power Platform Delete Unmanaged Solution'
-  inputs:
-    authenticationType: PowerPlatformSPN
-    PowerPlatformSPN: '$(ServiceConnName)'
-    SolutionName: '$(SolutionName)'
+      - task: PowerPlatformDeleteSolution@0
+        displayName: 'Power Platform Delete Unmanaged Solution (DOES NOT DELETE SOLUTION COMPONENTS)'
+        inputs:
+          authenticationType: PowerPlatformSPN
+          PowerPlatformSPN: '$(ServiceConnName)'
+          SolutionName: '$(SolutionName)'
 
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.import-solution.PowerPlatformImportSolution@0
-  displayName: 'Import Managed Solution'
-  inputs:
-    authenticationType: PowerPlatformSPN
-    PowerPlatformSPN: '$(ServiceConnName)'
-    SolutionInputFile: '$(build.binariesdirectory)\$(SolutionName).zip'
-    OverwriteUnmanagedCustomizations: true
-    PublishWorkflows: false
-    ConvertToManaged: true
+# If the import failed, we can't continue with the cleanup process. 
+# A common cause of this is that a canvas app is still open in the studio and therefore import is blocked.
+# To accomodate for import failures, we separate into two stages so we can rerun the import stage if it fails.
+# This gives the maker an opportunity to resolve the issue, and rerun the second stage which will try to import/delete the managed solution again.
+# Maker can continute to rerun the stage (trial/error) until there are no more import errors.
 
-- task: PowerPlatformDeleteSolution@0
-  displayName: 'Power Platform Delete Managed Solution'
-  inputs:
-    authenticationType: PowerPlatformSPN
-    PowerPlatformSPN: '$(ServiceConnName)'
-    SolutionName: '$(SolutionName)'
+- stage: importAndDeleteManaged
+  jobs:
+    - job: importAndDeleteManaged  
+      pool:
+        vmImage: ${{ variables.vmImage }}
+      steps:
+      - checkout: none
+
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          buildType: 'current'
+          artifactName: 'drop'
+          targetPath: '$(Pipeline.Workspace)\'
+
+      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@0
+        displayName: 'Power Platform Tool Installer '
+
+      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.import-solution.PowerPlatformImportSolution@0
+        displayName: 'Import Managed Solution'
+        inputs:
+          authenticationType: PowerPlatformSPN
+          PowerPlatformSPN: '$(ServiceConnName)'
+          SolutionInputFile: '$(Pipeline.Workspace)\$(SolutionName).zip'
+          OverwriteUnmanagedCustomizations: true
+          PublishWorkflows: false
+          ConvertToManaged: true
+
+      - powershell: |
+          $errorMessage = "Since the import failed, your environment is in an unhealthy state. "
+          $errorMessage = $errorMessage + "The unmanaged container is gone, but the unmanaged solution components still exist in the environment. "
+          $errorMessage = $errorMessage + "Fix whatever is causing the import to fail, then you can rerun this stage."
+          Write-Host "##vso[task.logissue type=error]$errorMessage"
+          Write-Host "##[task.complete result=Failed]DONE"
+        displayName: 'Log error'
+        condition: failed()
+
+      - task: PowerPlatformDeleteSolution@0
+        displayName: 'Power Platform Delete Managed Solution'
+        inputs:
+          authenticationType: PowerPlatformSPN
+          PowerPlatformSPN: '$(ServiceConnName)'
+          SolutionName: '$(SolutionName)'


### PR DESCRIPTION
Public preview release of the ALM Accelerator For Advanced Makers. Included in this release are the following enhancements/fixes.

The major update in this release is a change to the pipelines to remove the reliance on build completion triggers to simplify setup and provide a better experience when applying branch policies. In the previous release we had a build pipeline and seperate deployment pipelines for each environment. This made setup cumbersome and also didn't address several issues including:

Ensuring that both the build and deployment to validation succeeded when running the validation build via the branch policy. Instead the previous version would only validate the build and then a user would have to go to the deployment pipeline to determine if the deployment succeeded.
Allow for deployment without build. In the previous version a build was kicked off for every deployment. The feedback we've gotten is that in some cases (e.g. when deploying to prod) organizations want to be able to deploy the most recent build that was deployed to test.
Both of the above issues have been handled in the latest release pipelines and the setup instructions have been updated to demonstrate how to handle both scenarios by using a single pipeline per environment to which a solution is being deployed.

NOTE: If you are upgrading to the latest public preview you will need to perform the following steps.

Delete or deactivate your build pipeline.
Update your Branch policy to point to the pipeline deploy-validation-MySolution
Upgrade to the latest AA4AM Solution
Update your pipeline templates repo with the latest from https://github.com/microsoft/coe-alm-accelerator-templates
Follow the instructions in the SETUPGUIDE.md to create / update your solution deployment pipelines (e.g. deploy-validation-MySolution, deploy-test-MySolution and deploy-prod-MySolution) found here https://github.com/microsoft/coe-starter-kit/blob/main/PowerPlatformDevOpsALM/SETUPGUIDE.md#setting-deployment-pipeline-variables
Issues addressed in this release:

Pipelines: Update CoE Starter Kit Pipelines to Deploy without Build to Prod #238
Pipelines: Non-namespaced Build Task #219
AA4AM Docs: Updates #185
ALM Accelerator Sample Solution: No longer operable #228
AA4AM: Readme Doc #213
Service connection related permission issue while running the pipelines #177
Pipelines: Update build pipeline for PRs to not use build completion triggers #160
Add required connectors to documentation #191
AA4AM App: Add hover tooltip for long solution names #112
AA4AM App: Sort Solutions Alphabetically #116
Pipelines: Spaces in projects / repos cause errors in pipelines #180
Improve readability of GETTINGSTARTED.md #182
AA4AM App: Update Custom Connector Description #167