### PR TITLE
Fixes Microsoft/coe-starter-kit#368

### DIFF
--- a/Pipelines/Templates/export-Solution.yml
+++ b/Pipelines/Templates/export-Solution.yml
@@ -125,7 +125,7 @@ steps:
    Get-ChildItem -Path "$(Build.SourcesDirectory)\${{parameters.Repo}}\${{parameters.SolutionName}}" -Recurse -Filter *.json | 
    ForEach-Object {
        $formatted = .\jq.exe . $_.FullName
-       $formatted | Out-File $_.FullName 
+       $formatted | Out-File $_.FullName -Encoding UTF8
    }
    del jq.exe
    del $(Build.ArtifactStagingDirectory)\${{parameters.SolutionName}}.zip


### PR DESCRIPTION
Fixes Microsoft/coe-starter-kit#368 json encoding issue with GitHub. I've verified this will fix the issue with json files being marked as binary in PRs in GitHub. However, it will only show the fix once both branches involved in the merge have been updated with the UTF-8 encoded files.