### PR TITLE
handle spaces in project name

### DIFF
--- a/Pipelines/sync-pipeline-repo.yml
+++ b/Pipelines/sync-pipeline-repo.yml
@@ -67,7 +67,7 @@ stages:
         displayName: 'Push ${{parameters.BranchToCreate}} to AzDO repo'
 
         # Set default org and project
-      - powershell: az devops configure --defaults organization=$(System.CollectionUri) project=$(System.TeamProject)
+      - powershell: az devops configure --defaults organization=$(System.CollectionUri) project="$(System.TeamProject)"
         displayName: 'Set az devops defaults'
 
         # Create Pull Requests


### PR DESCRIPTION
If the sync pipeline is executed for a project that has spaces in its name, the pipeline fails with the following error message. The change prevents that error from occuring.

ERROR: usage error: --defaults STRING=STRING STRING=STRING ...