### PR TITLE
Clear contents of all *_connectionparameters.json before commit.

### DIFF
--- a/Pipelines/Templates/export-Solution.yml
+++ b/Pipelines/Templates/export-Solution.yml
@@ -113,6 +113,17 @@ steps:
   displayName: 'unpack msapp files'
   enabled: true
 
+# TEMPORARY until Solution export supports not exporting custom connector configurations
+# We need to clear out the contents of any *_connectionparameters.json file.  This is to ensure those valuse
+# are not overwritten when the Solution is imported to a downstream environment.
+- powershell: |   
+   Get-ChildItem -Path "$(Build.SourcesDirectory)\${{parameters.Repo}}\${{parameters.SolutionName}}" -Recurse -Filter *_connectionparameters.json | 
+   ForEach-Object {
+       Clear-Content $_.FullName
+   }
+  displayName: 'Clear contents of *_connectionparameters.json files'
+  enabled: true
+  
 # TEMPORARY until SolutionPackager supports formatting json files on unpack we
 # update all the json files to be pretty-print / formatted so they are easier to read in source control.
 # This also makes it easier to read changes from one commit to another


### PR DESCRIPTION
Fix for https://github.com/microsoft/coe-starter-kit/issues/78

However, since this fix depends on a platform fix that will likely not be rolled out for 4-6 weeks, I won't close the actual issue.  

Even without the dependent issue, we would have likely added this capability to the pipelines since much of what is in the *_connectionparameters.json files is environment specific configuration that we don't want in source control.