### PR TITLE
Add issue template chooser in place of the "Please File Issues at..." issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Issues
+    url: https://github.com/microsoft/coe-starter-kit/issues
+    about: Please file issues in the microsoft/coe-starter-kit repository.


### PR DESCRIPTION
Hey team,

I have seen you have added a "Please File Issues at..." issue to the repository to guide people to the [microsoft/coe-starter-kit](https://github.com/microsoft/coe-starter-kit) repository for the creation of issues.

I thought it could be interesting to leverage the [issue template chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) GitHub feature to address this requirement.

I hope this small update will help.

Have a great day 😊