### PR TITLE
Process Activation - try-catch and additional info on log

### DIFF
--- a/Pipelines/Templates/activate-flows.yml
+++ b/Pipelines/Templates/activate-flows.yml
@@ -40,6 +40,7 @@ steps:
     # Currently only implementing workflow ownership change until we indentify real usage scenarios for other solution components needing ownership change post import.
     # See https://docs.microsoft.com/en-us/dynamics365/customer-engagement/web-api/solutioncomponent?view=dynamics-ce-odata-9
     # ...for solutionComponentType values 29=Workflow (including Flow), 300=Canvas App, etc 
+    Write-Host "##[group]Activating Solution Components"
     foreach ($activateConfig in $config){
         if($activateConfig.activateAsUser -ne '' -and $activateConfig.solutionComponentUniqueName -ne ''){
             $workflow = Get-CrmRecord -conn $conn -EntityLogicalName workflow -Id $activateConfig.solutionComponentUniqueName -Fields clientdata,category,statecode,name
@@ -51,13 +52,21 @@ steps:
                 if($workflow.statecode -ne "Activated"){
                     $impersonationConn = Get-CrmConnection -ConnectionString "$(CdsBaseConnectionString)${{parameters.serviceConnection}}"
                     $impersonationCallerId = $systemUserId
-                    $impersonationConn.OrganizationWebProxyClient.CallerId = $impersonationCallerId 
-                    Write-Host "Enabling Flows"
-                    Set-CrmRecordState -conn $impersonationConn -EntityLogicalName workflow -Id $activateConfig.solutionComponentUniqueName -StateCode Activated -StatusCode Activated
+                    Write-Host "Enabling $($workflow.category) $($workflow.name) as $($systemusers.CrmRecords[0].FullName) ($($systemusers.CrmRecords[0].systemuserid))"
+                    Set-CrmConnectionCallerId -conn $impersonationConn -CallerId $impersonationCallerId
+                    Write-Host "Enabling $($workflow.category) $($workflow.name)"
+                    try {
+                        Set-CrmRecordState -conn $impersonationConn -EntityLogicalName workflow -Id $activateConfig.solutionComponentUniqueName -StateCode Activated -StatusCode Activated
+                    }
+                    catch
+                    {
+                        Write-Host "##vso[task.logissue type=error]Failed to enable $($workflow.category) $($workflow.name)"
+                    }
                 }
             }
         }
     }
+    Write-Host "##[endgroup]"
   displayName: 'Activate Flows for Configuration'
   condition: and(succeeded(), ne(variables['EnableFlows'], 'false'), ne('$(outActivateFlows.outActivateFlows)', ''))
 
@@ -90,6 +99,7 @@ steps:
             $solutionComponents = $result.CrmRecords
 
             $config = ConvertFrom-Json '${{parameters.connectionReferences}}'
+            Write-Host "##[group]Activating Solution Components"
             foreach ($connectionRefConfig in $config) {
                 if($connectionRefConfig.LogicalName -ne '' -and $connectionRefConfig.ConnectionId -ne '') {
                     # Get the connection reference to update
@@ -112,11 +122,18 @@ steps:
 
                             foreach ($solutionComponent in $solutionComponents){
                                 if ($solutionComponent.componenttype -eq "Workflow"){
-                                    $workflow = Get-CrmRecord -conn $conn -EntityLogicalName workflow -Id $solutionComponent.objectid -Fields clientdata,category,statecode
+                                    $workflow = Get-CrmRecord -conn $conn -EntityLogicalName workflow -Id $solutionComponent.objectid -Fields clientdata,category,statecode,name
                                     if($workflow.clientdata.Contains($connectionRefConfig.LogicalName) -and $workflow.statecode -ne "Activated"){
-                                        Write-Host "Enabling Flows"
-                                        $impersonationConn.OrganizationWebProxyClient.CallerId = $impersonationCallerId 
-                                        Set-CrmRecordState -conn $impersonationConn -EntityLogicalName workflow -Id $solutionComponent.objectid -StateCode Activated -StatusCode Activated
+                                      Write-Host "Enabling $($workflow.category) $($workflow.name) as $($systemusers.CrmRecords[0].FullName) ($($systemusers.CrmRecords[0].systemuserid))"
+                                      Set-CrmConnectionCallerId -conn $impersonationConn -CallerId $impersonationCallerId
+                                      try 
+                                      {
+                                          Set-CrmRecordState -conn $impersonationConn -EntityLogicalName workflow -Id $solutionComponent.objectid -StateCode Activated -StatusCode Activated
+                                      }
+                                      catch
+                                      {
+                                          Write-Host "##vso[task.logissue type=error]Failed to enable $($workflow.category) $($workflow.name): $($_.Exception.Message)"
+                                      }
                                     }
                                 }
                             }
@@ -126,6 +143,7 @@ steps:
             }
         }
     }
+    Write-Host "##[endgroup]"
   displayName: 'Activate Flows for Connection References'
   condition: and(succeeded(), ne(variables['EnableFlows'], 'false'), ne('$(outConnectionReferences.outConnectionReferences)', ''))
 

--- a/Pipelines/Templates/activate-flows.yml
+++ b/Pipelines/Templates/activate-flows.yml
@@ -42,7 +42,7 @@ steps:
     # ...for solutionComponentType values 29=Workflow (including Flow), 300=Canvas App, etc 
     foreach ($activateConfig in $config){
         if($activateConfig.activateAsUser -ne '' -and $activateConfig.solutionComponentUniqueName -ne ''){
-            $workflow = Get-CrmRecord -conn $conn -EntityLogicalName workflow -Id $activateConfig.solutionComponentUniqueName -Fields clientdata,category,statecode
+            $workflow = Get-CrmRecord -conn $conn -EntityLogicalName workflow -Id $activateConfig.solutionComponentUniqueName -Fields clientdata,category,statecode,name
             $systemuserResult = Get-CrmRecords -conn $conn -EntityLogicalName systemuser -FilterAttribute "domainname" -FilterOperator "eq" -FilterValue $activateConfig.activateAsUser
             $systemUserId = $systemuserResult.CrmRecords[0].systemuserid
 
@@ -51,8 +51,12 @@ steps:
                 $impersonationConn = Get-CrmConnection -ConnectionString "$(CdsBaseConnectionString)${{parameters.serviceConnection}}"
                 $impersonationCallerId = $systemUserId
                 $impersonationConn.OrganizationWebProxyClient.CallerId = $impersonationCallerId 
-                Write-Host "Enabling Flows"
-                Set-CrmRecordState -conn $impersonationConn -EntityLogicalName workflow -Id $activateConfig.solutionComponentUniqueName -StateCode Activated -StatusCode Activated
+                Write-Host "Enabling $($workflow.category) $($workflow.name)"
+                try {
+                  Set-CrmRecordState -conn $impersonationConn -EntityLogicalName workflow -Id $activateConfig.solutionComponentUniqueName -StateCode Activated -StatusCode Activated
+                }catch {
+                  Write-Host "Failed to enable $($workflow.category) $($workflow.name).." -ForegroundColor Red
+                }
             }
         }
     }

--- a/Pipelines/Templates/activate-flows.yml
+++ b/Pipelines/Templates/activate-flows.yml
@@ -58,8 +58,7 @@ steps:
                     try {
                         Set-CrmRecordState -conn $impersonationConn -EntityLogicalName workflow -Id $activateConfig.solutionComponentUniqueName -StateCode Activated -StatusCode Activated
                     }
-                    catch
-                    {
+                    catch {
                         Write-Host "##vso[task.logissue type=error]Failed to enable $($workflow.category) $($workflow.name)"
                     }
                 }
@@ -126,12 +125,10 @@ steps:
                                     if($workflow.clientdata.Contains($connectionRefConfig.LogicalName) -and $workflow.statecode -ne "Activated"){
                                       Write-Host "Enabling $($workflow.category) $($workflow.name) as $($systemusers.CrmRecords[0].FullName) ($($systemusers.CrmRecords[0].systemuserid))"
                                       Set-CrmConnectionCallerId -conn $impersonationConn -CallerId $impersonationCallerId
-                                      try 
-                                      {
+                                      try {
                                           Set-CrmRecordState -conn $impersonationConn -EntityLogicalName workflow -Id $solutionComponent.objectid -StateCode Activated -StatusCode Activated
                                       }
-                                      catch
-                                      {
+                                      catch {
                                           Write-Host "##vso[task.logissue type=error]Failed to enable $($workflow.category) $($workflow.name): $($_.Exception.Message)"
                                       }
                                     }

--- a/Pipelines/Templates/activate-flows.yml
+++ b/Pipelines/Templates/activate-flows.yml
@@ -41,6 +41,7 @@ steps:
     # See https://docs.microsoft.com/en-us/dynamics365/customer-engagement/web-api/solutioncomponent?view=dynamics-ce-odata-9
     # ...for solutionComponentType values 29=Workflow (including Flow), 300=Canvas App, etc 
     Write-Host "##[group]Activating Solution Components"
+    $isException = $false
     foreach ($activateConfig in $config){
         if($activateConfig.activateAsUser -ne '' -and $activateConfig.solutionComponentUniqueName -ne ''){
             $workflow = Get-CrmRecord -conn $conn -EntityLogicalName workflow -Id $activateConfig.solutionComponentUniqueName -Fields clientdata,category,statecode,name
@@ -60,12 +61,16 @@ steps:
                     }
                     catch {
                         Write-Host "##vso[task.logissue type=error]Failed to enable $($workflow.category) $($workflow.name)"
+                        $isException = $true
                     }
                 }
             }
         }
     }
     Write-Host "##[endgroup]"
+    if($isException) {
+      throw "Failed to enable one or more workflows"
+    }
   displayName: 'Activate Flows for Configuration'
   condition: and(succeeded(), ne(variables['EnableFlows'], 'false'), ne('$(outActivateFlows.outActivateFlows)', ''))
 
@@ -99,6 +104,7 @@ steps:
 
             $config = ConvertFrom-Json '${{parameters.connectionReferences}}'
             Write-Host "##[group]Activating Solution Components"
+            $isException = $false
             foreach ($connectionRefConfig in $config) {
                 if($connectionRefConfig.LogicalName -ne '' -and $connectionRefConfig.ConnectionId -ne '') {
                     # Get the connection reference to update
@@ -130,6 +136,7 @@ steps:
                                       }
                                       catch {
                                           Write-Host "##vso[task.logissue type=error]Failed to enable $($workflow.category) $($workflow.name): $($_.Exception.Message)"
+                                          $isException = $true
                                       }
                                     }
                                 }
@@ -141,6 +148,9 @@ steps:
         }
     }
     Write-Host "##[endgroup]"
+    if($isException) {
+      throw "Failed to enable one or more workflows"
+    }    
   displayName: 'Activate Flows for Connection References'
   condition: and(succeeded(), ne(variables['EnableFlows'], 'false'), ne('$(outConnectionReferences.outConnectionReferences)', ''))
 

--- a/Pipelines/Templates/update-solution-component-ownership.yml
+++ b/Pipelines/Templates/update-solution-component-ownership.yml
@@ -62,7 +62,6 @@ steps:
                 $workflow.statecode = "Draft"
             }
             Set-CrmRecordOwner -conn $conn $workflow $systemUserId
-
           }
 
           #Activate the workflow using the owner.
@@ -74,8 +73,7 @@ steps:
             try {
                 Set-CrmRecordState -conn $impersonationConn -EntityLogicalName workflow -Id $ownershipConfig.solutionComponentUniqueName -StateCode Activated -StatusCode Activated
             }
-            catch
-            {
+            catch {
                 Write-Host "##vso[task.logissue type=error]Failed to enable $($workflow.category) $($workflow.name): $($_.Exception.Message)"
             }
           }

--- a/Pipelines/Templates/update-solution-component-ownership.yml
+++ b/Pipelines/Templates/update-solution-component-ownership.yml
@@ -36,6 +36,7 @@ steps:
     # Currently only implementing workflow ownership change until we indentify real usage scenarios for other solution components needing ownership change post import.
     # See https://docs.microsoft.com/en-us/dynamics365/customer-engagement/web-api/solutioncomponent?view=dynamics-ce-odata-9
     # ...for solutionComponentType values 29=Workflow (including Flow), 300=Canvas App, etc 
+    Write-Host "##[group]Reassigning Ownership of components"
     foreach ($ownershipConfig in $config){
       if($ownershipConfig.ownerEmail -ne '' -and $ownershipConfig.solutionComponentType -ne '' -and $ownershipConfig.solutionComponentUniqueName -ne ''){
           switch ($ownershipConfig.solutionComponentType){
@@ -52,7 +53,7 @@ steps:
           $systemUserId = $systemuserResult.CrmRecords[0].systemuserid
           $impersonationConn = Get-CrmConnection -ConnectionString "$(CdsBaseConnectionString)${{parameters.serviceConnection}}"
           $impersonationCallerId = $systemUserId
-          $impersonationConn.OrganizationWebProxyClient.CallerId = $impersonationCallerId 
+          Set-CrmConnectionCallerId -conn $impersonationConn -CallerId $impersonationCallerId
 
           if('${{parameters.updateComponentOnwership}}' -ne "false") {
             #Need to deactivate the flow before setting ownership if currently active
@@ -68,12 +69,19 @@ steps:
           if($workflow.statecode -ne "Activated" -and '${{parameters.enableFlows}}' -ne "false"){
             $impersonationConn = Get-CrmConnection -ConnectionString "$(CdsBaseConnectionString)${{parameters.serviceConnection}}"
             $impersonationCallerId = $systemUserId
-            $impersonationConn.OrganizationWebProxyClient.CallerId = $impersonationCallerId 
-            Write-Host "Enabling Flows"
-            Set-CrmRecordState -conn $impersonationConn -EntityLogicalName workflow -Id $ownershipConfig.solutionComponentUniqueName -StateCode Activated -StatusCode Activated
+            Set-CrmConnectionCallerId -conn $impersonationConn -CallerId $impersonationCallerId
+            Write-Host "Enabling $($workflow.category) $($workflow.name) as $($systemuserResult.CrmRecords[0].FullName) as ($($systemuserResult.CrmRecords[0].systemuserid))"
+            try {
+                Set-CrmRecordState -conn $impersonationConn -EntityLogicalName workflow -Id $ownershipConfig.solutionComponentUniqueName -StateCode Activated -StatusCode Activated
+            }
+            catch
+            {
+                Write-Host "##vso[task.logissue type=error]Failed to enable $($workflow.category) $($workflow.name): $($_.Exception.Message)"
+            }
           }
       }
     }
+    Write-Host "##[endgroup]"
     
   displayName: '${{parameters.displayName}}'
   condition: and(succeeded(), ne('${{parameters.solutionComponentOwnershipConfiguration}}', ''))

--- a/Pipelines/Templates/update-solution-component-ownership.yml
+++ b/Pipelines/Templates/update-solution-component-ownership.yml
@@ -37,6 +37,7 @@ steps:
     # See https://docs.microsoft.com/en-us/dynamics365/customer-engagement/web-api/solutioncomponent?view=dynamics-ce-odata-9
     # ...for solutionComponentType values 29=Workflow (including Flow), 300=Canvas App, etc 
     Write-Host "##[group]Reassigning Ownership of components"
+    $isException = $false
     foreach ($ownershipConfig in $config){
       if($ownershipConfig.ownerEmail -ne '' -and $ownershipConfig.solutionComponentType -ne '' -and $ownershipConfig.solutionComponentUniqueName -ne ''){
           switch ($ownershipConfig.solutionComponentType){
@@ -75,11 +76,14 @@ steps:
             }
             catch {
                 Write-Host "##vso[task.logissue type=error]Failed to enable $($workflow.category) $($workflow.name): $($_.Exception.Message)"
+                $isException = $true
             }
           }
       }
     }
     Write-Host "##[endgroup]"
-    
+    if($isException) {
+      throw "Failed to enable one or more workflows"
+    }
   displayName: '${{parameters.displayName}}'
   condition: and(succeeded(), ne('${{parameters.solutionComponentOwnershipConfiguration}}', ''))


### PR DESCRIPTION
If any one process fails to activate, the whole pipeline fails. So, I added try catch in this scenario, so all valid processes can be activated. I also added additional info in the log: process category and name of the process, so that it is easy to troubleshoot in case there is a failure.