### PR TITLE
Bug #1423 - remove possible '.' from conref solution comp id

### DIFF
--- a/Pipelines/Templates/update-deployment-settings.yml
+++ b/Pipelines/Templates/update-deployment-settings.yml
@@ -74,10 +74,12 @@ steps:
     $currentGroupTeams = $currentCustomConfiguration.AadGroupTeamConfiguration
 
     $solutionComponentDefinitionsResults =  Get-CrmRecords -conn $conn -EntityLogicalName solutioncomponentdefinition -FilterAttribute "primaryentityname" -FilterOperator "eq" -FilterValue "connectionreference" -Fields objecttypecode
+    #There is an extra '.' character being introduced in specific locales. The regex replace on the objecttypecode below is to remove it.
     $connectionReferenceTypeCode = $solutionComponentDefinitionsResults.CrmRecords[0].objecttypecode -replace '\.',''
     foreach($solutioncomponent in $solutionComponentResults.CrmRecords)
     {
         #Connection Reference
+        #There is an extra '.' character being introduced in specific locales. The regex replace on the objecttypecode below is to remove it.
         $solutioncomponentType = $solutioncomponent.componenttype_Property.Value.Value -replace '\.',''
         if(($solutioncomponentType -eq $connectionReferenceTypeCode) -and ('${{parameters.generateConnectionReferences}}' -ne 'false')) {
             # "ConnectionReferences": [

--- a/Pipelines/Templates/update-deployment-settings.yml
+++ b/Pipelines/Templates/update-deployment-settings.yml
@@ -74,11 +74,12 @@ steps:
     $currentGroupTeams = $currentCustomConfiguration.AadGroupTeamConfiguration
 
     $solutionComponentDefinitionsResults =  Get-CrmRecords -conn $conn -EntityLogicalName solutioncomponentdefinition -FilterAttribute "primaryentityname" -FilterOperator "eq" -FilterValue "connectionreference" -Fields objecttypecode
-    $connectionReferenceTypeCode = $solutionComponentDefinitionsResults.CrmRecords[0].objecttypecode
+    $connectionReferenceTypeCode = $solutionComponentDefinitionsResults.CrmRecords[0].objecttypecode -replace '\.',''
     foreach($solutioncomponent in $solutionComponentResults.CrmRecords)
     {
         #Connection Reference
-        if($solutioncomponent.componenttype_Property.Value.Value -eq $connectionReferenceTypeCode -and '${{parameters.generateConnectionReferences}}' -ne 'false') {
+        $solutioncomponentType = $solutioncomponent.componenttype_Property.Value.Value -replace '\.',''
+        if(($solutioncomponentType -eq $connectionReferenceTypeCode) -and ('${{parameters.generateConnectionReferences}}' -ne 'false')) {
             # "ConnectionReferences": [
             # {
             #    "LogicalName": "cat_CDS_Current",


### PR DESCRIPTION
[link to bug in question](https://github.com/microsoft/coe-starter-kit/issues/1423#issue-1039541330)

I have not tried to reproduce the bug in more than one environment/region, so I am not 100 % of the impact.

I decided that removing all '.' from both queries (see the changes) was unintrusive, but we might want to do a more clever comparison, like first checking whether there are any '.' at all.
