### PR TITLE
Getting EnvironmentID from XRM Tooling instead of Admin PA cmdlets

### DIFF
--- a/Pipelines/Templates/set-environment-id.yml
+++ b/Pipelines/Templates/set-environment-id.yml
@@ -4,6 +4,14 @@ parameters:
 
 steps:
 - powershell: |  
+    $cmdletVersion = '$(xrmToolingVersion)'
+    if(!$cmdletVersion.Contains("xrmToolingVersion")) {
+      Write-Host("Installing specified version of Microsoft.Xrm.Tooling.CrmConnector.PowerShell");
+      Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -AllowClobber -RequiredVersion $cmdletVersion
+    } else {
+      Write-Host("Installing latest version of Microsoft.Xrm.Tooling.CrmConnector.PowerShell");
+      Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -AllowClobber
+    }
     $conn = Get-CrmConnection -ConnectionString "$(CdsBaseConnectionString)${{parameters.serviceConnection}}"
     # Get the Environment name (which is a GUID)
     $environmentId = $conn.EnvironmentId 

--- a/Pipelines/Templates/set-environment-id.yml
+++ b/Pipelines/Templates/set-environment-id.yml
@@ -4,14 +4,6 @@ parameters:
 
 steps:
 - powershell: |  
-    $cmdletVersion = '$(xrmToolingVersion)'
-    if(!$cmdletVersion.Contains("xrmToolingVersion")) {
-      Write-Host("Installing specified version of Microsoft.Xrm.Tooling.CrmConnector.PowerShell");
-      Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -AllowClobber -RequiredVersion $cmdletVersion
-    } else {
-      Write-Host("Installing latest version of Microsoft.Xrm.Tooling.CrmConnector.PowerShell");
-      Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -AllowClobber
-    }
     $conn = Get-CrmConnection -ConnectionString "$(CdsBaseConnectionString)${{parameters.serviceConnection}}"
     # Get the Environment name (which is a GUID)
     $environmentId = $conn.EnvironmentId 

--- a/Pipelines/Templates/set-environment-id.yml
+++ b/Pipelines/Templates/set-environment-id.yml
@@ -6,8 +6,10 @@ steps:
 - powershell: |  
     $cmdletVersion = '$(xrmToolingVersion)'
     if(!$cmdletVersion.Contains("xrmToolingVersion")) {
+      Write-Host("Installing specified version of Microsoft.Xrm.Tooling.CrmConnector.PowerShell");
       Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -RequiredVersion $cmdletVersion
     } else {
+      Write-Host("Installing latest version of Microsoft.Xrm.Tooling.CrmConnector.PowerShell");
       Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force
     }
     $connstr = "AuthType=ClientSecret;ClientId=$(ClientId);ClientSecret=$(ClientSecret);url=$(CdsBaseConnectionString)" 

--- a/Pipelines/Templates/set-environment-id.yml
+++ b/Pipelines/Templates/set-environment-id.yml
@@ -4,18 +4,12 @@ parameters:
 
 steps:
 - powershell: |    
-    Import-Module Microsoft.PowerApps.Administration.PowerShell -Force -RequiredVersion $(PowerAppsAdminModuleVersion) -ArgumentList @{ NonInteractive = $true }
-    Add-PowerAppsAccount -TenantID $(TenantId) -ApplicationId $(ClientId) -ClientSecret $(ClientSecret)
-    Import-Module Microsoft.Xrm.Data.PowerShell -Force -RequiredVersion $(XrmDataPowerShellVersion) -ArgumentList @{ NonInteractive = $true }
-    $conn = Get-CrmConnection -ConnectionString "$(CdsBaseConnectionString)${{parameters.serviceConnection}}"
-
-    # Get the EnvironmentName (which is a GUID) of the environment based on the orgid in Dataverse
-    $orgId = (Get-CrmRecords -conn $conn -EntityLogicalName organization).CrmRecords[0].organizationid
-
-    # Get the Environment using the InstanceId
-    $environment = Get-AdminPowerAppEnvironment -InstanceId $orgId
+    Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force #-RequiredVersion $(PowerAppsAdminModuleVersion)
+    $connstr = "AuthType=ClientSecret;ClientId=$(ClientId);ClientSecret=$(ClientSecret);url=$(CdsBaseConnectionString)" 
+    # Get the CrmConnection object which includes the org and environment IDs.
+    $conn = Get-CrmConnection -ConnectionString $connstr
     # Get the Environment name (which is a GUID)
-    $environmentId = $environment.EnvironmentName    
+    $environmentId = $conn.EnvironmentId 
     # Set the EnvironmentId as a global variable for use in other templates
     echo "##vso[task.setvariable variable=EnvironmentId]$environmentId"
   displayName: 'Set EnvironmentId'

--- a/Pipelines/Templates/set-environment-id.yml
+++ b/Pipelines/Templates/set-environment-id.yml
@@ -5,7 +5,7 @@ parameters:
 steps:
 - powershell: |  
     $cmdletVersion = '$(xrmToolingVersion)'
-    if($cmdletVersion.Contains("xrmToolingVersion")) {
+    if(!$cmdletVersion.Contains("xrmToolingVersion")) {
       Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -RequiredVersion $cmdletVersion
     } else {
       Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force

--- a/Pipelines/Templates/set-environment-id.yml
+++ b/Pipelines/Templates/set-environment-id.yml
@@ -3,7 +3,13 @@ parameters:
   type: string
 
 steps:
-- powershell: |    
+- powershell: |  
+    $cmdletVersion = '$(xrmToolingVersion)'
+    if($cmdletVersion -ne '') {
+      Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -RequiredVersion $cmdletVersion
+    } else {
+      Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force
+    }
     Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force #-RequiredVersion $(PowerAppsAdminModuleVersion)
     $connstr = "AuthType=ClientSecret;ClientId=$(ClientId);ClientSecret=$(ClientSecret);url=$(CdsBaseConnectionString)" 
     # Get the CrmConnection object which includes the org and environment IDs.

--- a/Pipelines/Templates/set-environment-id.yml
+++ b/Pipelines/Templates/set-environment-id.yml
@@ -12,7 +12,7 @@ steps:
       Write-Host("Installing latest version of Microsoft.Xrm.Tooling.CrmConnector.PowerShell");
       Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -AllowClobber
     }
-    $connstr = "AuthType=ClientSecret;ClientId=$(ClientId);ClientSecret=$(ClientSecret);url=$(CdsBaseConnectionString)" 
+    $conn = Get-CrmConnection -ConnectionString "$(CdsBaseConnectionString)${{parameters.serviceConnection}}"
     # Get the CrmConnection object which includes the org and environment IDs.
     $conn = Get-CrmConnection -ConnectionString $connstr
     # Get the Environment name (which is a GUID)

--- a/Pipelines/Templates/set-environment-id.yml
+++ b/Pipelines/Templates/set-environment-id.yml
@@ -7,10 +7,10 @@ steps:
     $cmdletVersion = '$(xrmToolingVersion)'
     if(!$cmdletVersion.Contains("xrmToolingVersion")) {
       Write-Host("Installing specified version of Microsoft.Xrm.Tooling.CrmConnector.PowerShell");
-      Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -RequiredVersion $cmdletVersion
+      Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -AllowClobber -RequiredVersion $cmdletVersion
     } else {
       Write-Host("Installing latest version of Microsoft.Xrm.Tooling.CrmConnector.PowerShell");
-      Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force
+      Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -AllowClobber
     }
     $connstr = "AuthType=ClientSecret;ClientId=$(ClientId);ClientSecret=$(ClientSecret);url=$(CdsBaseConnectionString)" 
     # Get the CrmConnection object which includes the org and environment IDs.

--- a/Pipelines/Templates/set-environment-id.yml
+++ b/Pipelines/Templates/set-environment-id.yml
@@ -13,8 +13,6 @@ steps:
       Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -AllowClobber
     }
     $conn = Get-CrmConnection -ConnectionString "$(CdsBaseConnectionString)${{parameters.serviceConnection}}"
-    # Get the CrmConnection object which includes the org and environment IDs.
-    $conn = Get-CrmConnection -ConnectionString $connstr
     # Get the Environment name (which is a GUID)
     $environmentId = $conn.EnvironmentId 
     # Set the EnvironmentId as a global variable for use in other templates

--- a/Pipelines/Templates/set-environment-id.yml
+++ b/Pipelines/Templates/set-environment-id.yml
@@ -10,7 +10,6 @@ steps:
     } else {
       Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force
     }
-    Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force #-RequiredVersion $(PowerAppsAdminModuleVersion)
     $connstr = "AuthType=ClientSecret;ClientId=$(ClientId);ClientSecret=$(ClientSecret);url=$(CdsBaseConnectionString)" 
     # Get the CrmConnection object which includes the org and environment IDs.
     $conn = Get-CrmConnection -ConnectionString $connstr

--- a/Pipelines/Templates/set-environment-id.yml
+++ b/Pipelines/Templates/set-environment-id.yml
@@ -5,7 +5,7 @@ parameters:
 steps:
 - powershell: |  
     $cmdletVersion = '$(xrmToolingVersion)'
-    if($cmdletVersion -ne '') {
+    if($cmdletVersion.Contains("xrmToolingVersion")) {
       Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force -RequiredVersion $cmdletVersion
     } else {
       Install-Module -Name Microsoft.Xrm.Tooling.CrmConnector.PowerShell -Force


### PR DESCRIPTION
Implementing the change to get the Environment ID from the URL used in the connection string and combining with Get-CRMConnection from XRM Tooling cmdlets.


