### PR TITLE
cast values from strings back to integers

### DIFF
--- a/Pipelines/Templates/update-deployment-settings.yml
+++ b/Pipelines/Templates/update-deployment-settings.yml
@@ -75,12 +75,14 @@ steps:
 
     $solutionComponentDefinitionsResults =  Get-CrmRecords -conn $conn -EntityLogicalName solutioncomponentdefinition -FilterAttribute "primaryentityname" -FilterOperator "eq" -FilterValue "connectionreference" -Fields objecttypecode
     #There is an extra '.' character being introduced in specific locales. The regex replace on the objecttypecode below is to remove it.
-    $connectionReferenceTypeCode = $solutionComponentDefinitionsResults.CrmRecords[0].objecttypecode -replace '\.',''
+    #Convert it back to a integer to fix an issue with a comma appearing when converting to a string
+    $connectionReferenceTypeCode = [int] ($solutionComponentDefinitionsResults.CrmRecords[0].objecttypecode -replace '\.','')
+    
     foreach($solutioncomponent in $solutionComponentResults.CrmRecords)
     {
         #Connection Reference
         #There is an extra '.' character being introduced in specific locales. The regex replace on the objecttypecode below is to remove it.
-        $solutioncomponentType = $solutioncomponent.componenttype_Property.Value.Value -replace '\.',''
+        $solutioncomponentType = ($solutioncomponent.componenttype_Property.Value.Value -replace '\.','')
         if(($solutioncomponentType -eq $connectionReferenceTypeCode) -and ('${{parameters.generateConnectionReferences}}' -ne 'false')) {
             # "ConnectionReferences": [
             # {

--- a/Pipelines/Templates/update-deployment-settings.yml
+++ b/Pipelines/Templates/update-deployment-settings.yml
@@ -82,7 +82,7 @@ steps:
     {
         #Connection Reference
         #There is an extra '.' character being introduced in specific locales. The regex replace on the objecttypecode below is to remove it.
-        $solutioncomponentType = ($solutioncomponent.componenttype_Property.Value.Value -replace '\.','')
+        $solutioncomponentType = [int] ($solutioncomponent.componenttype_Property.Value.Value -replace '\.','')
         if(($solutioncomponentType -eq $connectionReferenceTypeCode) -and ('${{parameters.generateConnectionReferences}}' -ne 'false')) {
             # "ConnectionReferences": [
             # {


### PR DESCRIPTION
Updated update-deployment-settings.yml to fix an issue with the connectionReferenceTypeCode outputting as a string (e.g., 10,049) instead as an integer (10049) causing the comparison to fail and deployment settings not being pushed between environments