### PR TITLE
Added code to remove tab characters from the body

### DIFF
--- a/Pipelines/Templates/update-deployment-settings.yml
+++ b/Pipelines/Templates/update-deployment-settings.yml
@@ -300,6 +300,8 @@ steps:
             $headers.Add("Authorization", "Bearer $env:SYSTEM_ACCESSTOKEN")
             $headers.Add("Content-Type", "application/json")
             $body = ConvertTo-Json -Depth 10 $buildDefinitionResult
+            #remove tab charcters from the body
+            $body = $body -replace "\\t", ""            
             Invoke-RestMethod $buildDefinitionResourceUrl -Method 'PUT' -Headers $headers -Body ([System.Text.Encoding]::UTF8.GetBytes($body)) | Out-Null
         }
     }


### PR DESCRIPTION
Tab characters cause a failure in the posting of the JSON build definition back to DevOps