### PR TITLE
Changed check in activate flows for connections

### DIFF
--- a/Pipelines/Templates/activate-flows.yml
+++ b/Pipelines/Templates/activate-flows.yml
@@ -106,7 +106,8 @@ steps:
       
                         # Get connection
                         $connections = Get-AdminPowerAppConnection -EnvironmentName $environmentName -Filter $connectionRefConfig.ConnectionId
-                        if($connections.Count -gt 0) {
+                        #connections doesn't have a count property and causes an error trying to activate the flowws
+                        if($null -ne $connections) {
                             # Get Dataverse systemuserid for the system user that maps to the aad user guid that created the connection 
                             $systemusers = Get-CrmRecords -conn $conn -EntityLogicalName systemuser -FilterAttribute "azureactivedirectoryobjectid" -FilterOperator "eq" -FilterValue $connections[0].CreatedBy.id
                             if($systemusers.Count -gt 0) {


### PR DESCRIPTION
For the connections that are returned from Get-AdminPowerAppConnection, the count property is not present and causes an issue when trying to activate the flows.  Instead check for null