### PR TITLE
Update activate-flows.yml

### DIFF
--- a/Pipelines/Templates/activate-flows.yml
+++ b/Pipelines/Templates/activate-flows.yml
@@ -117,8 +117,14 @@ steps:
                         # The temporary workaround is to impersonate the user that created the connection
       
                         if(-Not [string]::IsNullOrWhiteSpace($systemUserId)) {
+                            # The ConnectionOwner variable may contain an email address - if so change the attribute we filter on
+                            $filterAttribute = "azureactivedirectoryobjectid"
+                            if($systemUserId -Match "@") {
+                                $filterAttribute = "domainname"
+                            }
+
                             # Get Dataverse systemuserid for the system user that maps to the aad user guid that created the connection 
-                            $systemusers = Get-CrmRecords -conn $conn -EntityLogicalName systemuser -FilterAttribute "azureactivedirectoryobjectid" -FilterOperator "eq" -FilterValue $systemUserId
+                            $systemusers = Get-CrmRecords -conn $conn -EntityLogicalName systemuser -FilterAttribute $filterAttribute -FilterOperator "eq" -FilterValue $systemUserId
                             if($systemusers.Count -gt 0) {
                                 # Impersonate the Dataverse systemuser that created the connection when updating the connection reference
                                 $impersonationCallerId = $systemusers.CrmRecords[0].systemuserid


### PR DESCRIPTION
Added support for $connectionRefConfig.ConnectionOwner variable to contain an email address - if it does switch the systemuser lookup to filter by email address.

Ref: [https://github.com/microsoft/coe-starter-kit/issues/2137](https://github.com/microsoft/coe-starter-kit/issues/2137)