### PR TITLE
Corrected the Comment in export-Solution.yml file

### DIFF
--- a/Pipelines/Templates/export-Solution.yml
+++ b/Pipelines/Templates/export-Solution.yml
@@ -334,7 +334,7 @@ steps:
   displayName: 'Push to ${{parameters.branchToCreate}} Remote Branch'
   condition: and(eq('${{parameters.gitAccessUrl}}', ''), succeeded(), ne(variables.BranchToCreate, '')) # If an empty value is not passed for the BranchToCreate variable, then run this task
 
-# If BranchToCreate variable value is '', then push to the branch specified in the BranchToCreate variable
+# If BranchToCreate variable value is '', then push to the branch specified in the Branch variable
 - script: |
    git remote set-url origin ${{parameters.gitAccessUrl}}
    git push origin ${{parameters.branch}}


### PR DESCRIPTION
Corrected the 'Comment' in the 'export-Solution.yml' file under 'Pipelines\Templates' folder. 
Following is the explanation to this PR:
- When the BranchToCreate variable is not provided Push happens to the branch specified in the Branch variable. But in the comment, it was wrongly mentioned as BranchToCreate variable.
- Corrected the 'Comment' from "If BranchToCreate variable value is '', then push to the branch specified in the _BranchToCreate_ variable" to "If BranchToCreate variable value is '', then push to the branch specified in the _Branch_ variable".