### PR TITLE
Pipelines: Showcase using new Power Pages CI/CD tooling #163

### DIFF
--- a/Pipelines/Templates/Hooks/deploy-portal-post-hook.yml
+++ b/Pipelines/Templates/Hooks/deploy-portal-post-hook.yml
@@ -1,0 +1,4 @@
+steps:
+  - script: echo Deploy Portal Post Hook
+    displayName: 'Deploy Portal Post Hook'
+    enabled: false

--- a/Pipelines/Templates/Hooks/deploy-portal-pre-hook.yml
+++ b/Pipelines/Templates/Hooks/deploy-portal-pre-hook.yml
@@ -1,0 +1,4 @@
+steps:
+  - script: echo Deploy Portal Pre Hook
+    displayName: 'Deploy Portal Pre Hook'
+    enabled: false

--- a/Pipelines/Templates/Hooks/export-portal-post-hook.yml
+++ b/Pipelines/Templates/Hooks/export-portal-post-hook.yml
@@ -1,0 +1,4 @@
+steps:
+  - script: echo Export Portal Post Hook
+    displayName: 'Export Portal Post Hook'
+    enabled: false

--- a/Pipelines/Templates/Hooks/export-portal-pre-hook.yml
+++ b/Pipelines/Templates/Hooks/export-portal-pre-hook.yml
@@ -1,0 +1,4 @@
+steps:
+  - script: echo Export Portal Pre Hook
+    displayName: 'Deploy Portal Pre Hook'
+    enabled: false

--- a/Pipelines/Templates/build-Solution.yml
+++ b/Pipelines/Templates/build-Solution.yml
@@ -169,6 +169,14 @@ steps:
     RuleSet: '0ad12346-e108-40b8-a956-9a8f95ea18c9'
   condition: and(succeeded(), and(ne(variables['DisableSolutionChecker'], 'true'), eq(variables['Build.Reason'], 'PullRequest')))
 
+#Copy portal to artifacts
+- powershell: |
+    $source = "$(Build.SourcesDirectory)\$(RepoName)\${{parameters.solutionName}}\Portals\${{parameters.solutionName}}"
+    $dest = "$(Build.ArtifactStagingDirectory)\Portals\${{parameters.solutionName}}"
+    if(Test-Path $source) {
+        Copy-Item $source $dest -Recurse -Force
+    }
+  displayName: 'Copy Portal to Artifacts'
 - task: PublishPipelineArtifact@1
   displayName: 'Publish Artifacts'
   inputs:

--- a/Pipelines/Templates/deploy-Solution.yml
+++ b/Pipelines/Templates/deploy-Solution.yml
@@ -285,3 +285,11 @@ steps:
     testAccountPassword: '$(TestAutomationPassword)'
     makerPortalUrl: '$(TestAutomationMakerPortalUrl)'
     loginMethod: '$(TestAutomationLoginMethod)'
+
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.upload-paportal.PowerPlatformUploadPaportal@0
+  displayName: 'Upload Portal ${{parameters.solutionName}}'
+  inputs:
+    authenticationType: PowerPlatformSPN
+    PowerPlatformSPN: '${{parameters.serviceConnectionName}}'
+    UploadPath: $(ArtifactDropPath)\Portals\${{parameters.solutionName}}
+    Environment: '${{parameters.serviceConnectionUrl}}'

--- a/Pipelines/Templates/deploy-Solution.yml
+++ b/Pipelines/Templates/deploy-Solution.yml
@@ -286,10 +286,14 @@ steps:
     makerPortalUrl: '$(TestAutomationMakerPortalUrl)'
     loginMethod: '$(TestAutomationLoginMethod)'
 
+- template: Hooks\deploy-portal-pre-hook.yml
+
 - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.upload-paportal.PowerPlatformUploadPaportal@0
   displayName: 'Upload Portal ${{parameters.solutionName}}'
   inputs:
     authenticationType: PowerPlatformSPN
     PowerPlatformSPN: '${{parameters.serviceConnectionName}}'
-    UploadPath: $(ArtifactDropPath)\Portals\aaa
+    UploadPath: $(ArtifactDropPath)\Portals\${{parameters.solutionName}}
     Environment: '${{parameters.serviceConnectionUrl}}'
+
+- template: Hooks\deploy-portal-post-hook.yml

--- a/Pipelines/Templates/deploy-Solution.yml
+++ b/Pipelines/Templates/deploy-Solution.yml
@@ -291,5 +291,5 @@ steps:
   inputs:
     authenticationType: PowerPlatformSPN
     PowerPlatformSPN: '${{parameters.serviceConnectionName}}'
-    UploadPath: $(ArtifactDropPath)\Portals\${{parameters.solutionName}}
+    UploadPath: $(ArtifactDropPath)\Portals\aaa
     Environment: '${{parameters.serviceConnectionUrl}}'

--- a/Pipelines/Templates/export-Portal.yml
+++ b/Pipelines/Templates/export-Portal.yml
@@ -1,0 +1,43 @@
+#We are going to set websiteId as a pipeline variable only if there is a portal in the Dataverse
+
+parameters:
+- name: websiteId
+  type: string
+- name: repo
+  type: string
+- name: serviceConnectionUrl
+  type: string
+- name: serviceConnectionName
+  type: string
+  #In case of exporting portal, we expect that the solution unique name will be the same as the portal name
+- name: solutionName
+  type: string
+
+steps:
+- powershell: | 
+   $websiteId = '${{parameters.websiteId}}'
+   Write-Host "WebsiteId: $websiteId"
+   if ($websiteId -eq $null -or $websiteId -eq '') {
+      Write-Host 'No WebsiteId found'
+      return
+   }
+  displayName: 'Validate WebsiteId Variable'
+
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@0
+  displayName: 'Power Platform Tool Installer'
+ 
+#TODO Because the override flag is not exposed yet in tools, so we need to clear the folder manually
+- powershell: |
+    if(Test-Path $(Build.SourcesDirectory)\${{parameters.repo}}\${{parameters.solutionName}}\Portals\${{parameters.solutionName}}){
+      Remove-Item $(Build.SourcesDirectory)\${{parameters.repo}}\${{parameters.solutionName}}\Portals\${{parameters.solutionName}}\* -Recurse -Force
+    }
+  displayName: 'Clear Download Folder'
+
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.download-paportal.PowerPlatformDownloadPaportal@0
+  displayName: 'Export Portal ${{parameters.solutionName}} from ${{parameters.serviceConnectionUrl}}'
+  inputs:
+    authenticationType: PowerPlatformSPN
+    PowerPlatformSPN: '${{parameters.serviceConnectionName}}'
+    Environment: '${{parameters.serviceConnectionUrl}}'
+    DownloadPath: $(Build.SourcesDirectory)\${{parameters.repo}}\${{parameters.solutionName}}\Portals\
+    WebsiteId: ${{parameters.websiteId}}

--- a/Pipelines/Templates/export-Solution.yml
+++ b/Pipelines/Templates/export-Solution.yml
@@ -315,6 +315,23 @@ steps:
   displayName: 'Verify Default Environment Variables Are Set'
   condition: and(succeeded(), eq(variables.VerifyDefaultEnvironmentVariableValues, 'true'))
 
+- template: set-website-variable.yml
+  parameters:
+   serviceConnectionUrl: '${{parameters.serviceConnectionUrl}}'
+   solutionName: '${{parameters.solutionName}}' 
+
+- template: Hooks\export-portal-pre-hook.yml
+
+- template: export-Portal.yml
+  parameters:
+    websiteId: $(WebsiteId)
+    repo: ${{parameters.repo}}
+    serviceConnectionUrl: '${{parameters.serviceConnectionUrl}}'
+    serviceConnectionName: '${{parameters.serviceConnectionName}}'
+    solutionName: '${{parameters.solutionName}}'
+
+- template: Hooks\export-portal-post-hook.yml
+
 - template: Hooks\export-solution-commit-pre-hook.yml
 
 - powershell: |

--- a/Pipelines/Templates/set-website-variable.yml
+++ b/Pipelines/Templates/set-website-variable.yml
@@ -1,0 +1,38 @@
+#We are going to set websiteId as a pipeline variable only if there is a portal in the Dataverse
+
+parameters:
+- name: serviceConnectionUrl
+  type: string
+  #In case of exporting portal, we expect that the solution unique name will be the same as the portal name
+- name: solutionName
+  type: string
+
+steps:
+- powershell: | 
+    $websiteId = ${env:WEBSITEID}
+    if ($websiteId -ne $null -and $websiteId -ne '') {
+      #WebsiteId is set in the pipeline variable. We don't need to do anything.
+      exit 0
+    }
+
+    # load PowerShell files into memory
+    . "$env:POWERSHELLPATH/dataverse-webapi-functions.ps1"
+    $dataverseHost = Get-HostFromUrl "${{parameters.serviceConnectionUrl}}"
+    $odataQuery = "adx_websites?`$filter=adx_name eq '${{parameters.solutionName}}'"    
+
+    try{
+      $response = Invoke-DataverseHttpGet $env:SPNTOKEN $dataverseHost $odataQuery
+    }
+    catch{
+      #Write-Host "Error: $($_.Exception.Message)"
+      # if portal' solutions are not installed in Dataverse. adx_websites table will not be created.
+      exit 0
+    }
+    if($null -eq $response.value -or $response.value.count -eq 0){
+      # portal with the given name is not found in Dataverse.
+      exit 0
+    }
+    $websiteId = $response.value[0].adx_websiteid
+    #Write-Host "WebsiteId: $($websiteId)"
+    echo "##vso[task.setvariable variable=WebsiteId]$websiteId"
+  displayName: 'Set Website Variable'

--- a/Pipelines/build-deploy-prod-SampleSolution.yml
+++ b/Pipelines/build-deploy-prod-SampleSolution.yml
@@ -16,7 +16,8 @@ trigger:
     - SampleSolutionName/SolutionPackage/ # Replace SolutionFolder with actual folder name in repo
     - SampleSolutionName/Plugins/ # Replace SolutionFolder with actual folder name in repo
     - SampleSolutionName/WebResources/ # Replace SolutionFolder with actual folder name in repo
-    
+    - SampleSolutionName/Portals/ # Replace SolutionFolder with actual folder name in repo
+        
 name: 1.0.$(Date:yyyyMMdd)$(Rev:.r)
 
 # NOTE: If you want to use different values for these variables, you can remove the variable group and attach them directly to this pipeline. The group specified below is a variable group defined in the Library for the Pipelines

--- a/Pipelines/build-deploy-test-SampleSolution.yml
+++ b/Pipelines/build-deploy-test-SampleSolution.yml
@@ -16,6 +16,7 @@ trigger:
     - SampleSolutionName/SolutionPackage/ # Replace SolutionFolder with actual folder name in repo
     - SampleSolutionName/Plugins/ # Replace SolutionFolder with actual folder name in repo
     - SampleSolutionName/WebResources/ # Replace SolutionFolder with actual folder name in repo
+    - SampleSolutionName/Portals/ # Replace SolutionFolder with actual folder name in repo
     
 name: 1.0.$(Date:yyyyMMdd)$(Rev:.r)
 

--- a/Pipelines/build-deploy-validation-SampleSolution.yml
+++ b/Pipelines/build-deploy-validation-SampleSolution.yml
@@ -16,7 +16,8 @@ trigger:
     - SampleSolutionName/SolutionPackage/ # Replace SolutionFolder with actual folder name in repo
     - SampleSolutionName/Plugins/ # Replace SolutionFolder with actual folder name in repo
     - SampleSolutionName/WebResources/ # Replace SolutionFolder with actual folder name in repo
-    
+    - SampleSolutionName/Portals/ # Replace SolutionFolder with actual folder name in repo
+ 
 name: 1.0.$(Date:yyyyMMdd)$(Rev:.r)
 
 # NOTE: If you want to use different values for these variables, you can remove the variable group and attach them directly to this pipeline. The group specified below is a variable group defined in the Library for the Pipelines


### PR DESCRIPTION
Adding code to support Power Portal upload/download functionality in the pipelines according to Issue 
https://github.com/microsoft/coe-starter-kit/issues/163 

In order to not change the canvas app, I look for a portal that has the same name as a given uniqueSoltuionName of a solution being deployed. 

Done:
- portal download, if a portal of a given solution name will be found on Dataverse
- if pipeline contains variable named "WebsiteId" then its value will be used to search for a portal and not the solution name
- portal upload pre/post hooks
- portal dowload pre/post hooks

Not implemented:
- support for deployment profiles
- portal versioning 


