### PR TITLE
Solution upgrade vs update pipeline and ps script changes

### DIFF
--- a/Pipelines/Templates/deploy-Solution.yml
+++ b/Pipelines/Templates/deploy-Solution.yml
@@ -134,12 +134,12 @@ steps:
     Write-Host "$TriggerSolutionUpgrade - $(TriggerSolutionUpgrade)"
     Write-Output "##vso[task.setvariable variable=TriggerSolutionUpgrade;isOutput=true]$(TriggerSolutionUpgrade)"
 
-    ## If Solution Upgrade was not set at Canvas App, check whether PR has Tag
-    #if(!$triggerSolutionUpgrade)
-    #{
-    #    . "$env:POWERSHELLPATH/set-trigger-solution-upgrade.ps1"
-    #    Set-TriggerSolutionUpgrade '$(TriggerSolutionUpgrade)' '$(System.TeamFoundationCollectionUri)' '$(System.TeamProjectId)' '$(Build.Repository.Name)' '$(Build.Repository.Provider)' '$(Build.SourceVersion)' '$(Build.Reason)' '$(GitHubRepo)' '$(GitHubPAT)'
-    #}
+    # If Solution Upgrade was not set at Canvas App Deployment Settings screen, check whether PR has Tag.
+    if(!$triggerSolutionUpgrade)
+    {
+        . "$env:POWERSHELLPATH/set-trigger-solution-upgrade.ps1"
+        Set-TriggerSolutionUpgrade '$(TriggerSolutionUpgrade)' '$(System.TeamFoundationCollectionUri)' '$(System.TeamProjectId)' '$(Build.Repository.Name)' '$(Build.Repository.Provider)' '$(Build.SourceVersion)' '$(Build.Reason)' '$(GitHubRepo)' '$(GitHubPAT)'
+    }
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
   name: setTriggerSolutionUpgrade

--- a/Pipelines/Templates/deploy-Solution.yml
+++ b/Pipelines/Templates/deploy-Solution.yml
@@ -129,9 +129,17 @@ steps:
   displayName: 'Get managed solution zip path'
   condition: and(succeeded(), ne('${{parameters.importUnmanaged}}', 'true'))
 
-- pwsh: |    
-    . "$env:POWERSHELLPATH/set-trigger-solution-upgrade.ps1"
-    Set-TriggerSolutionUpgrade '$(TriggerSolutionUpgrade)' '$(System.TeamFoundationCollectionUri)' '$(System.TeamProjectId)' '$(Build.Repository.Name)' '$(Build.Repository.Provider)' '$(Build.SourceVersion)' '$(Build.Reason)' '$(GitHubRepo)' '$(GitHubPAT)'
+- pwsh: |   
+    # Read the Trigger Solution Upgrade flag from pipeline variable
+    Write-Host "$TriggerSolutionUpgrade - $(TriggerSolutionUpgrade)"
+    Write-Output "##vso[task.setvariable variable=TriggerSolutionUpgrade;isOutput=true]$(TriggerSolutionUpgrade)"
+
+    ## If Solution Upgrade was not set at Canvas App, check whether PR has Tag
+    #if(!$triggerSolutionUpgrade)
+    #{
+    #    . "$env:POWERSHELLPATH/set-trigger-solution-upgrade.ps1"
+    #    Set-TriggerSolutionUpgrade '$(TriggerSolutionUpgrade)' '$(System.TeamFoundationCollectionUri)' '$(System.TeamProjectId)' '$(Build.Repository.Name)' '$(Build.Repository.Provider)' '$(Build.SourceVersion)' '$(Build.Reason)' '$(GitHubRepo)' '$(GitHubPAT)'
+    #}
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
   name: setTriggerSolutionUpgrade

--- a/PowerShell/update-deployment-settings.ps1
+++ b/PowerShell/update-deployment-settings.ps1
@@ -261,7 +261,6 @@
 
             $buildName = $buildDefinitionResult.name.ToLower()
             # Declare Solution Upgrade Tags; By default is 'update'
-            $solutionupgradeVariableName = "SolutionUpgrade"
             $solutionUpgradeInputValue = $false
             $pipelineVariableName =  "TriggerSolutionUpgrade"
             if($null -ne $configurationData) 
@@ -269,13 +268,12 @@
                 foreach($deploymentEnvironment in $configurationData) 
                 {
                     $deploymentBuildName = $deploymentEnvironment.BuildName.ToLower()
-                    Write-Host "deploymentBuildName - " $deploymentBuildName
                     if($deploymentBuildName -eq $buildName)
                     {
-                        $solutionUpgradeTag = $deploymentEnvironment.UserSettings | Where-Object { $_.Name -eq $solutionupgradeVariableName }
+                        $solutionUpgradeTag = $deploymentEnvironment.UserSettings | Where-Object { $_.Name -eq $pipelineVariableName }
                         if($null -ne $solutionUpgradeTag -and $null -ne $solutionUpgradeTag.Value)
                         {
-                            if($solutionUpgradeTag.Value -eq "upgrade")
+                            if($solutionUpgradeTag.Value -eq "true")
                             {
                                 $solutionUpgradeInputValue = $true
                             }

--- a/PowerShell/update-deployment-settings.ps1
+++ b/PowerShell/update-deployment-settings.ps1
@@ -45,7 +45,7 @@
         $flowActivationUsers = [System.Collections.ArrayList]@()
         $flowSharings = [System.Collections.ArrayList]@()
         $groupTeams = [System.Collections.ArrayList]@()
-        $cofigurationVariables = [System.Collections.ArrayList]@()
+        $configurationVariables = [System.Collections.ArrayList]@()
 
         #Convert the updated configuration to json and store in customDeploymentSettings.json
         $json = ConvertTo-Json -Depth 10 $newCustomConfiguration
@@ -78,8 +78,8 @@
                 $connnectionConfigVariable = "#{connectionreference." + $connRefName + "}#"
                 $connnectionOwnerConfigVariable = "#{connectionreference.user." + $connRefName + "}#"
                 $connRef = [PSCustomObject]@{"LogicalName"="$connRefName"; "ConnectionId"="$connnectionConfigVariable"; "ConnectorId"= "$connectorId"; "ConnectionOwner"="$connnectionOwnerConfigVariable" }
-                $cofigurationVariables.Add($connnectionConfigVariable)
-                $cofigurationVariables.Add($connnectionOwnerConfigVariable)
+                $configurationVariables.Add($connnectionConfigVariable)
+                $configurationVariables.Add($connnectionOwnerConfigVariable)
                 $connectionReferences.Add($connRef)
             }
             #Custom Connector Variable Definition
@@ -96,7 +96,7 @@
                 #Create the flow sharing deployment settings
                 $sharingConfigVariable = "#{connector.teamname." + $placeholdername + "}#"
                 $connectorSharingConfig = [PSCustomObject]@{"solutionComponentName"=$connectorResult.name; "solutionComponentUniqueName"=$solutionComponent.objectid; "aadGroupTeamName"="$sharingConfigVariable"}
-                $cofigurationVariables.Add($sharingConfigVariable)
+                $configurationVariables.Add($sharingConfigVariable)
                 $customConnectorSharings.Add($connectorSharingConfig)
             }
 
@@ -120,7 +120,7 @@
                 if($envVarResult.type_Property.Value.Value -eq 100000005) {
                     $secretEnvironmentVariables.Add($envVarName)
                 }
-                $cofigurationVariables.Add($envVarConfigVariable)
+                $configurationVariables.Add($envVarConfigVariable)
                 $environmentVariables.Add($envVar)
             }
             #Canvas App
@@ -139,8 +139,8 @@
                 $aadGroupConfigVariable = "#{canvasshare.aadGroupId." + $canvasName + "}#"
                 $groupRoleConfigVariable = "#{canvasshare.roleName." + $canvasName + "}#"
                 $canvasConfig = [PSCustomObject]@{"aadGroupId"="$aadGroupConfigVariable"; "canvasNameInSolution"=$canvasName; "canvasDisplayName"= $canvasAppResult.displayname; "roleName"="$groupRoleConfigVariable"}
-                $cofigurationVariables.Add($aadGroupConfigVariable)
-                $cofigurationVariables.Add($groupRoleConfigVariable)
+                $configurationVariables.Add($aadGroupConfigVariable)
+                $configurationVariables.Add($groupRoleConfigVariable)
                 $canvasApps.Add($canvasConfig)
             }
             #Workflow
@@ -168,13 +168,13 @@
                 $ownerConfigVariable = "#{owner.ownerEmail." + $placeholdername + "}#"
                 #Create the flow owner deployment settings
                 $flowConfig = [PSCustomObject]@{"solutionComponentType"=$solutioncomponent.componenttype_Property.Value.Value; "solutionComponentName"=$flowResult.name; "solutionComponentUniqueName"=$workflowName; "ownerEmail"="$ownerConfigVariable"}
-                $cofigurationVariables.Add($ownerConfigVariable)
+                $configurationVariables.Add($ownerConfigVariable)
                 $flowOwnerships.Add($flowConfig)
 
                 #Create the flow sharing deployment settings
                 $sharingConfigVariable = "#{flow.sharing." + $placeholdername + "}#"
                 $flowSharingConfig = [PSCustomObject]@{"solutionComponentName"=$flowResult.name; "solutionComponentUniqueName"=$workflowName; "aadGroupTeamName"="$sharingConfigVariable"}
-                $cofigurationVariables.Add($sharingConfigVariable)
+                $configurationVariables.Add($sharingConfigVariable)
                 $flowSharings.Add($flowSharingConfig)
 
                 #Create the flow activation user deployment settings
@@ -182,9 +182,9 @@
                 $activateConfigVariable = "#{activateflow.activate." + $placeholdername + "}#"
                 $activateUserConfigVariable = "#{activateflow.activateas." + $placeholdername + "}#"
                 $flowActivationUserConfig = [PSCustomObject]@{"solutionComponentName"=$flowResult.name; "solutionComponentUniqueName"=$workflowName; "activateAsUser"="$activateUserConfigVariable"; "sortOrder"="$sortOrderConfigVariable"; "activate"="$activateConfigVariable"}
-                $cofigurationVariables.Add($sortOrderConfigVariable)
-                $cofigurationVariables.Add($activateConfigVariable)
-                $cofigurationVariables.Add($activateUserConfigVariable)
+                $configurationVariables.Add($sortOrderConfigVariable)
+                $configurationVariables.Add($activateConfigVariable)
+                $configurationVariables.Add($activateUserConfigVariable)
                 $flowActivationUsers.Add($flowActivationUserConfig)
             }
         }
@@ -225,7 +225,7 @@
             $newBuildDefinitionVariables = $buildDefinitionResult.variables
             #Loop through each of the tokens stored above and find an associated variable in the configuration data passed in from AA4AM
 
-            foreach($configurationVariable in $cofigurationVariables) {
+            foreach($configurationVariable in $configurationVariables) {
                 $found = $false
                 $configurationVariable = $configurationVariable.replace('#{', '')
                 $configurationVariable = $configurationVariable.replace('}#', '')
@@ -255,6 +255,48 @@
                                 $newBuildDefinitionVariables.$configurationVariable.value = $variable.Value
                             }
                         }
+                    }
+                }
+            }
+
+            $buildName = $buildDefinitionResult.name.ToLower()
+            # Declare Solution Upgrade Tags; By default is 'update'
+            $solutionupgradeVariableName = "SolutionUpgrade"
+            $solutionUpgradeInputValue = $false
+            $pipelineVariableName =  "TriggerSolutionUpgrade"
+            if($null -ne $configurationData) 
+            {
+                foreach($deploymentEnvironment in $configurationData) 
+                {
+                    $deploymentBuildName = $deploymentEnvironment.BuildName.ToLower()
+                    Write-Host "deploymentBuildName - " $deploymentBuildName
+                    if($deploymentBuildName -eq $buildName)
+                    {
+                        $solutionUpgradeTag = $deploymentEnvironment.UserSettings | Where-Object { $_.Name -eq $solutionupgradeVariableName }
+                        if($null -ne $solutionUpgradeTag -and $null -ne $solutionUpgradeTag.Value)
+                        {
+                            if($solutionUpgradeTag.Value -eq "upgrade")
+                            {
+                                $solutionUpgradeInputValue = $true
+                            }
+                            Write-Host "solutionUpgradeInputValue for  $deploymentBuildName - $solutionUpgradeInputValue"
+
+                            $found = $false
+                            #See if the variable already exists
+                            foreach($buildVariable in $newBuildDefinitionVariables.PSObject.Properties) {
+                                if($buildVariable.Name -eq $pipelineVariableName) {
+                                    $found = $true
+                                    break
+                                }
+                            }
+                            #If the variable was not found create it 
+                            if(!$found) {
+                                $newBuildDefinitionVariables | Add-Member -MemberType NoteProperty -Name $pipelineVariableName -Value @{value = ''}
+                            }
+                            # Set the value to the value passed in on the configuration data
+                            $newBuildDefinitionVariables.$pipelineVariableName.value = $solutionUpgradeInputValue
+                        }
+                     break;
                     }
                 }
             }
@@ -410,7 +452,7 @@ function Set-EnvironmentDeploymentSettingsConfiguration {
                 $teamGroupRoles = $variableConfiguration.Data.split(',')
 
                 $groupTeamConfig = [PSCustomObject]@{"aadGroupTeamName"=$teamName; "aadSecurityGroupId"="$teamGroupConfigVariable"; "dataverseSecurityRoleNames"=@($teamGroupRoles)}
-                $cofigurationVariables.Add($teamGroupConfigVariable)
+                $configurationVariables.Add($teamGroupConfigVariable)
                 $groupTeams.Add($groupTeamConfig)
             }
         }


### PR DESCRIPTION
A new checkbox has been added in Accelerator Canvas App to capture user input (i.e., Update or Upgrade).
In DeploymentSettings ps file, added logic to read the checkbox value and add that as pipeline variable.
Fixes microsoft/coe-starter-kit#639
Fixes microsoft/coe-starter-kit#3011