### PR TITLE
Updating update-deployment-settings.ps1 to loop over all variables #3448

### DIFF
--- a/Pipelines/Templates/build-Solution.yml
+++ b/Pipelines/Templates/build-Solution.yml
@@ -25,7 +25,7 @@ steps:
 # Set pipeline vars for tools paths.
 - template: set-tools-paths.yml
     
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@2
   displayName: 'Install Power Platform Build Tools'
 
 - pwsh: |
@@ -112,15 +112,6 @@ steps:
     Invoke-ArchiveConfigurationMigrationData '$(Build.SourcesDirectory)' '$(Build.ArtifactStagingDirectory)' '$(RepoName)' '${{parameters.solutionName}}'
   displayName: 'Archive Configuration Migration Data'    
     
-# Update any deploymentSettings.json via FileTransform task. This task will replace values in a JSON file based on their path. See https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/transforms-variable-substitution?view=azure-devops&tabs=Classic#jsonvarsubs
-- task: FileTransform@1
-  displayName: 'File Transformation: deploymentSettings.json'
-  inputs:
-    folderPath: $(Build.SourcesDirectory)\$(RepoName)\${{parameters.solutionName}}\config\
-    targetFiles: '*deploymentSettings*.json'
-    fileType: json
-  condition: and(succeeded(), or(ne(variables['DeploymentSettingsPath'], ''), ne(variables['CustomDeploymentSettingsPath'], '')))
-
 # Third party task to replace tokens in files. The FileTransform above replaces JSON tokens based on their path as opposed to replacing text tokens in a file which can be more error prone in some cases.
 # If you aren't using this task it can be safely removed or disabled by setting enabled: false. Sample token: #{VariableNameToReplace}#
 - task: qetza.replacetokens.replacetokens-task.replacetokens@3
@@ -155,7 +146,7 @@ steps:
 - template: Hooks\build-solution-pack-pre-hook.yml
 
 #Pack the solution based on the build type parameter (Unmanaged, Managed or Both)
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.pack-solution.PowerPlatformPackSolution@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.pack-solution.PowerPlatformPackSolution@2
   displayName: 'Pack Solutions (Unmanaged and/or Managed)'
   inputs:
     SolutionSourceFolder: $(Build.SourcesDirectory)\$(RepoName)\${{parameters.solutionName}}\SolutionPackage
@@ -164,7 +155,7 @@ steps:
 
 
 #Run Solution Checker against our solution. This is currently only triggered for pipelines that trigger for Pull Requests
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.checker.PowerPlatformChecker@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.checker.PowerPlatformChecker@2
   displayName: 'Run Solution Checker'
   inputs:
     authenticationType: PowerPlatformSPN

--- a/Pipelines/Templates/deploy-Solution.yml
+++ b/Pipelines/Templates/deploy-Solution.yml
@@ -46,7 +46,7 @@ steps:
     cacheHitVar: powerPlatformToolsPath_IsCached
   condition: and(succeeded(), eq('${{parameters.cacheEnabled}}', 'true'))
 
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@2
   displayName: 'Install Power Platform Build Tools'
   condition: and(succeeded(), eq('${{parameters.skipBuildToolsInstaller}}', 'false'))
 
@@ -108,7 +108,7 @@ steps:
 - template: Hooks\deploy-solution-import-pre-hook.yml
 
 # If called from import-unmanaged-to-dev-environment.yml, this task will run to deploy an unmanaged solution
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.import-solution.PowerPlatformImportSolution@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.import-solution.PowerPlatformImportSolution@2
   displayName: 'Import Unmanaged Solution'
   inputs:
     authenticationType: PowerPlatformSPN
@@ -134,13 +134,9 @@ steps:
   displayName: 'Get managed solution zip path'
   condition: and(succeeded(), ne('${{parameters.importUnmanaged}}', 'true'))
 
-- pwsh: |   
-    # Read the Trigger Solution Upgrade flag from pipeline variable
-    Write-Host "$TriggerSolutionUpgrade - $(TriggerSolutionUpgrade)"
-    Write-Output "##vso[task.setvariable variable=TriggerSolutionUpgrade;isOutput=true]$(TriggerSolutionUpgrade)"
-
+- pwsh: |    
     # If Solution Upgrade was not set at Canvas App Deployment Settings screen, check whether PR has Tag.
-    if(!$triggerSolutionUpgrade)
+    if($(TriggerSolutionUpgrade).Contains("TriggerSolutionUpgrade"))
     {
         . "$env:POWERSHELLPATH/set-trigger-solution-upgrade.ps1"
         Set-TriggerSolutionUpgrade '$(TriggerSolutionUpgrade)' '$(System.TeamFoundationCollectionUri)' '$(System.TeamProjectId)' '$(Build.Repository.Name)' '$(Build.Repository.Provider)' '$(Build.SourceVersion)' '$(Build.Reason)' '$(GitHubRepo)' '$(GitHubPAT)'
@@ -152,7 +148,7 @@ steps:
   displayName: 'Set TriggerSolutionUpgrade Variable'
 
 # If the TriggerSolutionUpgrade variable is false, then import the solution as an Update
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.import-solution.PowerPlatformImportSolution@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.import-solution.PowerPlatformImportSolution@2
   displayName: 'Import Managed Solution as Update'
   inputs:
     authenticationType: PowerPlatformSPN
@@ -166,7 +162,7 @@ steps:
 
 # If the TriggerSolutionUpgrade variable is true, then import the solution as an Upgrade, staging it as a holding solution, so we can apply a solution Upgrade.
 # Doing this will ensure that items removed from the solution in development are also removed from the solution in the target environment after the Upgrade is applied.
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.import-solution.PowerPlatformImportSolution@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.import-solution.PowerPlatformImportSolution@2
   displayName: 'Import Managed Solution as Upgrade'
   inputs:
     authenticationType: PowerPlatformSPN
@@ -183,7 +179,7 @@ steps:
 # You would add steps to your pipeline here to accomplish this. 
 
 # If the TriggerSolutionUpgrade variable is true,then apply the solution Upgrade.
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.apply-solution-upgrade.PowerPlatformApplySolutionUpgrade@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.apply-solution-upgrade.PowerPlatformApplySolutionUpgrade@2
   inputs:
     authenticationType: 'PowerPlatformSPN'
     PowerPlatformSPN: '${{parameters.serviceConnectionName}}'
@@ -191,7 +187,7 @@ steps:
     AsyncOperation: true
   condition: and(succeeded(), eq(variables['setTriggerSolutionUpgrade.TriggerSolutionUpgrade'], 'true'), eq(variables['SolutionExists'], 'true'))
 
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.publish-customizations.PowerPlatformPublishCustomizations@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.publish-customizations.PowerPlatformPublishCustomizations@2
   displayName: 'Power Platform Publish Customizations '
   inputs:
     authenticationType: PowerPlatformSPN

--- a/Pipelines/Templates/deploy-Solution.yml
+++ b/Pipelines/Templates/deploy-Solution.yml
@@ -136,7 +136,7 @@ steps:
 
 - pwsh: |    
     # If Solution Upgrade was not set at Canvas App Deployment Settings screen, check whether PR has Tag.
-    if($(TriggerSolutionUpgrade).Contains("TriggerSolutionUpgrade"))
+    if("$(TriggerSolutionUpgrade)".Contains("TriggerSolutionUpgrade"))
     {
         . "$env:POWERSHELLPATH/set-trigger-solution-upgrade.ps1"
         Set-TriggerSolutionUpgrade '$(TriggerSolutionUpgrade)' '$(System.TeamFoundationCollectionUri)' '$(System.TeamProjectId)' '$(Build.Repository.Name)' '$(Build.Repository.Provider)' '$(Build.SourceVersion)' '$(Build.Reason)' '$(GitHubRepo)' '$(GitHubPAT)'

--- a/Pipelines/Templates/export-Solution.yml
+++ b/Pipelines/Templates/export-Solution.yml
@@ -257,12 +257,6 @@ steps:
   displayName: 'Verify Environment Variable Current Value Not Exported'
   condition: and(succeeded(), eq(variables.DoNotExportCurrentEnvironmentVariableValues, 'true'))
 
-# Set paths to deployment settings
-- template: set-deployment-configuration-paths.yml
-  parameters:
-    configPath: '$(Build.SourcesDirectory)\${{parameters.repo}}\${{parameters.solutionName}}\config\'
-    environmentName: ''
-
 - template: Hooks\export-solution-update-deploymentsettings-pre-hook.yml
 
 # Update deployment settings configuration
@@ -275,6 +269,12 @@ steps:
     solutionName: '${{parameters.solutionName}}'
     configurationData: '${{parameters.configurationData}}'
     useDeploymentSettingsPlaceholders: $(UseDeploymentSettingsPlaceholders)
+
+# Set paths to deployment settings
+- template: set-deployment-configuration-paths.yml
+  parameters:
+    configPath: '$(Build.SourcesDirectory)\${{parameters.repo}}\${{parameters.solutionName}}\config\'
+    environmentName: ''
 
 # Set deployment variable for Activate Flow Configuration
 - template: set-deployment-variable.yml

--- a/Pipelines/Templates/export-Solution.yml
+++ b/Pipelines/Templates/export-Solution.yml
@@ -91,20 +91,20 @@ steps:
   workingDirectory: $(Build.SourcesDirectory)\${{parameters.repo}}
   condition: and(succeeded(), ne('${{parameters.branchToCreate}}', 'Commit to existing branch specified in Branch parameter')) # If an empty value is passed for the BranchToCreate variable, then skip this task
 
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@2
   displayName: 'Install Power Platform Build Tools'
 
 - template: install-powershell-modules.yml
 
 # Before exporting the solution, publish solution customizations to ensure all the changes are exported
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.publish-customizations.PowerPlatformPublishCustomizations@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.publish-customizations.PowerPlatformPublishCustomizations@2
   displayName: 'Publish Customizations'
   inputs:
     authenticationType: PowerPlatformSPN
     PowerPlatformSPN: ${{parameters.serviceConnectionName}}
 
 # Export both unmanaged and managed to put into source control
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.export-solution.PowerPlatformExportSolution@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.export-solution.PowerPlatformExportSolution@2
   displayName: 'Export Unmanaged Solution'
   inputs:
     authenticationType: PowerPlatformSPN
@@ -112,7 +112,7 @@ steps:
     SolutionName: '${{parameters.solutionName}}'
     SolutionOutputFile: '$(Build.ArtifactStagingDirectory)\${{parameters.solutionName}}.zip'
 
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.export-solution.PowerPlatformExportSolution@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.export-solution.PowerPlatformExportSolution@2
   displayName: 'Export Managed Solution'
   inputs:
     authenticationType: PowerPlatformSPN
@@ -124,7 +124,7 @@ steps:
 - template: Hooks\export-solution-unpack-pre-hook.yml
 
 # Unpack contents of solution to make the contents source control friendly 
-- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.unpack-solution.PowerPlatformUnpackSolution@0
+- task: microsoft-IsvExpTools.PowerPlatform-BuildTools.unpack-solution.PowerPlatformUnpackSolution@2
   displayName: 'Power Platform Unpack Solution'
   inputs:
     SolutionInputFile: '$(Build.ArtifactStagingDirectory)\${{parameters.solutionName}}.zip'
@@ -274,12 +274,7 @@ steps:
     serviceConnection: '${{parameters.serviceConnectionUrl}}'
     solutionName: '${{parameters.solutionName}}'
     configurationData: '${{parameters.configurationData}}'
-    generateEnvironmentVariables: $(DeploymentSettings.GenerateEnvironmentVariables)
-    generateConnectionReferences: $(DeploymentSettings.GenerateConnectionReferences)
-    generateFlowConfig: $(DeploymentSettings.GenerateFlowOwnership)
-    generateCanvasSharingConfig: $(DeploymentSettings.GenerateCanvasAppSharing)
-    generateAADGroupTeamConfig: $(DeploymentSettings.GenerateAADGroupTeam)
-    generateCustomConnectorConfig: $(DeploymentSettings.GenerateCustomConnectorConfig)
+    useDeploymentSettingsPlaceholders: $(UseDeploymentSettingsPlaceholders)
 
 # Set deployment variable for Activate Flow Configuration
 - template: set-deployment-variable.yml

--- a/Pipelines/Templates/update-deployment-settings.yml
+++ b/Pipelines/Templates/update-deployment-settings.yml
@@ -11,30 +11,15 @@ parameters:
   type: string
 - name: configurationData
   type: string
-- name: generateEnvironmentVariables
+- name: useDeploymentSettingsPlaceholders
   type: string
   default: 'true'
-- name: generateConnectionReferences
-  type: string
-  default: 'true'
-- name: generateFlowConfig
-  type: string
-  default: 'true'
-- name: generateCanvasSharingConfig
-  type: string
-  default: 'true'
-- name: generateAADGroupTeamConfig
-  type: string
-  default: 'false'
-- name: generateCustomConnectorConfig
-  type: string
-  default: 'false'
 
 steps:
 - powershell: |
       # load PowerShell files into memory
       . "$env:POWERSHELLPATH/update-deployment-settings.ps1"
-      Set-DeploymentSettingsConfiguration '$(Build.SourcesDirectory)' '$(Build.Repository.Name)' '$(CdsBaseConnectionString)' '$(XrmDataPowerShellVersion)' '$(CoETools_Microsoft_Xrm_Data_PowerShell)' '${{parameters.orgUrl}}' '$(System.TeamProjectId)' '${{parameters.projectName}}' '${{parameters.repo}}' 'Bearer' '${{parameters.serviceConnection}}' '${{parameters.solutionName}}'
+      Set-DeploymentSettingsConfiguration '$(Build.SourcesDirectory)' '$(Build.Repository.Name)' '$(CdsBaseConnectionString)' '$(XrmDataPowerShellVersion)' '$(CoETools_Microsoft_Xrm_Data_PowerShell)' '${{parameters.orgUrl}}' '$(System.TeamProjectId)' '${{parameters.projectName}}' '${{parameters.repo}}' 'Bearer' '${{parameters.serviceConnection}}' '${{parameters.solutionName}}' '${{parameters.useDeploymentSettingsPlaceholders}}'
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     DEPLOYMENT_SETTINGS: ${{parameters.configurationData}}

--- a/Pipelines/Templates/update-deployment-settings.yml
+++ b/Pipelines/Templates/update-deployment-settings.yml
@@ -24,4 +24,4 @@ steps:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     DEPLOYMENT_SETTINGS: ${{parameters.configurationData}}
   displayName: 'Update Deployment Settings'
-  condition: succeeded()
+  condition: and(succeeded(), ne(variables.GenerateDeploymentSettings, 'false'))

--- a/Pipelines/delete-unmanaged-solution-and-components.yml
+++ b/Pipelines/delete-unmanaged-solution-and-components.yml
@@ -72,10 +72,10 @@ stages:
       # Set pipeline vars for tools paths.
       - template: Templates\set-tools-paths.yml
 
-      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@0
+      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@2
         displayName: 'Power Platform Tool Installer '
 
-      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.export-solution.PowerPlatformExportSolution@0
+      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.export-solution.PowerPlatformExportSolution@2
         displayName: 'Export Solution as Managed'
         inputs:
           authenticationType: PowerPlatformSPN
@@ -90,7 +90,7 @@ stages:
           artifact: 'drop'
           publishLocation: 'pipeline'
 
-      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.delete-solution.PowerPlatformDeleteSolution@0
+      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.delete-solution.PowerPlatformDeleteSolution@2
         displayName: 'Power Platform Delete Unmanaged Solution (DOES NOT DELETE SOLUTION COMPONENTS)'
         inputs:
           authenticationType: PowerPlatformSPN
@@ -120,10 +120,10 @@ stages:
       # Set pipeline vars for tools paths.
       - template: Templates\set-tools-paths.yml
 
-      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@0
+      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.tool-installer.PowerPlatformToolInstaller@2
         displayName: 'Power Platform Tool Installer '
 
-      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.import-solution.PowerPlatformImportSolution@0
+      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.import-solution.PowerPlatformImportSolution@2
         displayName: 'Import Managed Solution'
         inputs:
           authenticationType: PowerPlatformSPN
@@ -142,7 +142,7 @@ stages:
         displayName: 'Log error'
         condition: failed()
 
-      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.delete-solution.PowerPlatformDeleteSolution@0
+      - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.delete-solution.PowerPlatformDeleteSolution@2
         displayName: 'Power Platform Delete Managed Solution'
         inputs:
           authenticationType: PowerPlatformSPN

--- a/PowerShell/tests/TestRunners/update-deployment-settings.tests.runner.ps1
+++ b/PowerShell/tests/TestRunners/update-deployment-settings.tests.runner.ps1
@@ -1,7 +1,7 @@
 ﻿#Run in Windows Powershell
-function Invoke-DeploymentSettingsConfiguration-Test()
+function Invoke-DeploymentSettingsConfiguration-Test($usePlaceholders, $path)
 {
-    Set-Location -Path "..\"
+    Set-Location -Path $path
 
     $testConfig = Get-Content ".\TestData\update-deployment-settings-test.config.json" | ConvertFrom-Json
     $testDeploymentConfig = Get-Content ".\TestData\update-deployment-settings-test-deployment.json"
@@ -25,15 +25,11 @@ function Invoke-DeploymentSettingsConfiguration-Test()
         AuthType                            = "Basic"
         ServiceConnection                   = $testConfig.serviceConnection
         SolutionName                        = $testConfig.solutionName
-        GenerateEnvironmentVariables        = $testConfig.generateEnvironmentVariables
-        GenerateConnectionReferences        = $testConfig.generateConnectionReferences
-        GenerateFlowConfig                  = $testConfig.generateFlowConfig
-        GenerateCanvasSharingConfig         = $testConfig.generateCanvasSharingConfig
-        GenerateAADGroupTeamConfig          = $testConfig.generateAADGroupTeamConfig
-        GenerateCustomConnectorConfig       = $testConfig.generateCustomConnectorConfig
+        UsePlaceholders                     = $usePlaceholders
     }    
     $container = New-PesterContainer -Path $path -Data $data
     Invoke-Pester -Container $container
 }
 
-Invoke-DeploymentSettingsConfiguration-Test
+Invoke-DeploymentSettingsConfiguration-Test $false '../'
+Invoke-DeploymentSettingsConfiguration-Test $true './tests'

--- a/PowerShell/tests/update-deployment-settings.tests.ps1
+++ b/PowerShell/tests/update-deployment-settings.tests.ps1
@@ -1,16 +1,16 @@
 ﻿param(
     $DeploymentConfig, $AccessToken, $BuildSourceDirectory, $BuildRepositoryName, $CdsBaseConnectionString,
     $XrmDataPowerShellVersion, $MicrosoftXrmDataPowerShellModule, $OrgUrl, $ProjectId, $ProjectName, $Repo, $AuthType,
-    $ServiceConnection, $SolutionName, $GenerateEnvironmentVariables, $GenerateConnectionReferences, $GenerateFlowConfig,
-    $GenerateCanvasSharingConfig, $GenerateAADGroupTeamConfig, $GenerateCustomConnectorConfig
+    $ServiceConnection, $SolutionName, $UsePlaceholders
 )
 
 Describe 'Update-Deployment-Settings-Test' {
     It 'UpdateDeploymentSettings' -Tag 'UpdateDeploymentSettings' {
+        Set-Location -Path "..\"
         Install-Module $MicrosoftXrmDataPowerShellModule -RequiredVersion $XrmDataPowerShellVersion -Force -AllowClobber
         $env:SYSTEM_ACCESSTOKEN = $AccessToken
         $env:DEPLOYMENT_SETTINGS = $DeploymentConfig
-        . ..\update-deployment-settings.ps1
-        Set-DeploymentSettingsConfiguration $BuildSourceDirectory $BuildRepositoryName $CdsBaseConnectionString $XrmDataPowerShellVersion $MicrosoftXrmDataPowerShellModule $OrgUrl $ProjectId $ProjectName $Repo $AuthType $ServiceConnection $SolutionName $GenerateEnvironmentVariables $GenerateConnectionReferences $GenerateFlowConfig $GenerateCanvasSharingConfig $GenerateAADGroupTeamConfig $GenerateCustomConnectorConfig
+        . .\update-deployment-settings.ps1
+        Set-DeploymentSettingsConfiguration $BuildSourceDirectory $BuildRepositoryName $CdsBaseConnectionString $XrmDataPowerShellVersion $MicrosoftXrmDataPowerShellModule $OrgUrl $ProjectId $ProjectName $Repo $AuthType $ServiceConnection $SolutionName $UsePlaceholders
     }
 }

--- a/PowerShell/update-deployment-settings.ps1
+++ b/PowerShell/update-deployment-settings.ps1
@@ -13,30 +13,39 @@
         [Parameter(Mandatory)] [String]$azdoAuthType,
         [Parameter(Mandatory)] [String]$serviceConnection,
         [Parameter(Mandatory)] [String]$solutionName,
-        [Parameter()] [String]$generateEnvironmentVariables,
-        [Parameter()] [String]$generateConnectionReferences,
-        [Parameter()] [String]$generateFlowConfig,
-        [Parameter()] [String]$generateCanvasSharingConfig,
-        [Parameter()] [String]$generateAADGroupTeamConfig,
-        [Parameter()] [String]$generateCustomConnectorConfig
+        [Parameter()] [String]$usePlaceholders
     )
     $configurationData = $env:DEPLOYMENT_SETTINGS | ConvertFrom-Json
+    $reservedVariables = @("TriggerSolutionUpgrade")
     Write-Host (ConvertTo-Json -Depth 10 $configurationData)
+
+
     #Generate Deployment Settings
     Write-Host "Update Deployment Settings"
-    $customDeploymentSettingsFilePath = "$buildSourceDirectory\$repo\$solutionName\config\customDeploymentSettings.json"
-    $deploymentSettingsFilePath = "$buildSourceDirectory\$repo\$solutionName\config\deploymentSettings.json"
     if(!(Test-Path "$buildSourceDirectory\$repo\$solutionName\config\")) {
         New-Item "$buildSourceDirectory\$repo\$solutionName\" -Name "config" -ItemType "directory"
+    } else {
+        #Remove legacy deployment settings
+        Remove-Item "$buildSourceDirectory\$repo\$solutionName\config\*eploymentSettings.json" -Force
     }
+
+    #Update / Create Deployment Pipelines
+    New-DeploymentPipelines "$buildRepositoryName" "$orgUrl" "$projectName" "$repo" "$azdoAuthType" "$solutionName" $configurationData
+
+    $buildDefinitionResourceUrl = "$orgUrl$projectId/_apis/build/definitions?name=deploy-*-$solutionName&includeAllProperties=true&api-version=6.0"
+
+    $fullBuildDefinitionResponse = Invoke-RestMethod $buildDefinitionResourceUrl -Method Get -Headers @{
+        Authorization = "$azdoAuthType  $env:SYSTEM_ACCESSTOKEN"
+    }
+    $buildDefinitionResponseResults = $fullBuildDefinitionResponse.value
+
     Write-Host "Importing PowerShell Module: $microsoftXrmDataPowerShellModule - $xrmDataPowerShellVersion"
     Import-Module $microsoftXrmDataPowerShellModule -Force -RequiredVersion $xrmDataPowerShellVersion -ArgumentList @{ NonInteractive = $true }
     $conn = Get-CrmConnection -ConnectionString "$cdsBaseConnectionString$serviceConnection"
-    $solutions = Get-CrmRecords -conn $conn -EntityLogicalName solution -FilterAttribute "uniquename" -FilterOperator "eq" -FilterValue "$solutionName" -Fields solutionid
-    if($solutions.Count -gt 0) {
-        Write-Host "Found $solutions solution..."
-        $solutionId = $solutions.CrmRecords[0].solutionid
-        $solutionComponentResults =  Get-CrmRecords -conn $conn -EntityLogicalName solutioncomponent -FilterAttribute "solutionid" -FilterOperator "eq" -FilterValue $solutionId -Fields componenttype, solutioncomponentid, objectid
+
+    #Loop through the build definitions we found and update the pipeline variables based on the placeholders we put in the deployment settings files.
+    foreach($buildDefinitionResult in $buildDefinitionResponseResults)
+    {
         $connectionReferences = [System.Collections.ArrayList]@()
         $environmentVariables = [System.Collections.ArrayList]@()
         $canvasApps = [System.Collections.ArrayList]@()
@@ -45,263 +54,186 @@
         $flowActivationUsers = [System.Collections.ArrayList]@()
         $flowSharings = [System.Collections.ArrayList]@()
         $groupTeams = [System.Collections.ArrayList]@()
-        $configurationVariables = [System.Collections.ArrayList]@()
+        #Getting the build definition id and variables to be updated
+        $definitionId = $buildDefinitionResult.id
+        $newBuildDefinitionVariables = $buildDefinitionResult.variables
+        $configurationDataEnvironment = $configurationData | Where-Object { $_.BuildName -eq $buildDefinitionResult.name } | Select-Object -First 1
 
-        #Convert the updated configuration to json and store in customDeploymentSettings.json
-        $json = ConvertTo-Json -Depth 10 $newCustomConfiguration
-        Set-Content -Path $customDeploymentSettingsFilePath -Value $json
-
-        $secretEnvironmentVariables = [System.Collections.ArrayList]@()
-
-        $solutionComponentDefinitionsResults =  Get-CrmRecords -conn $conn -EntityLogicalName solutioncomponentdefinition -FilterAttribute "primaryentityname" -FilterOperator "eq" -FilterValue "connectionreference" -Fields objecttypecode
-        #There are extra characters being introduced in specific locales. The regex replace on the objecttypecode below is to remove it.
-        $connectionReferenceTypeCode = [int] ($solutionComponentDefinitionsResults.CrmRecords[0].objecttypecode -replace '\D','')
-    
-        Write-Host "Creating deployment configuration for solution components..."
-        foreach($solutioncomponent in $solutionComponentResults.CrmRecords)
-        {
-            #Connection Reference
-            #There are extra characters being introduced in specific locales for the componenttype. The regex replace on the componenttype below is to remove it.
-            $solutioncomponentType = [int] ($solutioncomponent.componenttype_Property.Value.Value -replace '\D','')
-            if(($solutioncomponentType -eq $connectionReferenceTypeCode) -and ("$generateConnectionReferences" -ne "false")) {
-                # "ConnectionReferences": [
-                # {
-                #    "LogicalName": "cat_CDS_Current",
-                #    "ConnectionId": "#{stage.cr.cat_CDS_Current}#",
-                #    "ConnectorId": "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps"
-                # }
-                #]
-                $connRefResult = Get-CrmRecord -conn $conn -EntityLogicalName connectionreference -Id $solutionComponent.objectid -Fields connectionreferencelogicalname, connectorid
-                $connRef = $null
-                $connRefName = $connRefResult.connectionreferencelogicalname
-                $connectorId = $connRefResult.connectorid
-                $connnectionConfigVariable = "#{connectionreference." + $connRefName + "}#"
-                $connnectionOwnerConfigVariable = "#{connectionreference.user." + $connRefName + "}#"
-                $connRef = [PSCustomObject]@{"LogicalName"="$connRefName"; "ConnectionId"="$connnectionConfigVariable"; "ConnectorId"= "$connectorId"; "ConnectionOwner"="$connnectionOwnerConfigVariable" }
-                $configurationVariables.Add($connnectionConfigVariable)
-                $configurationVariables.Add($connnectionOwnerConfigVariable)
-                $connectionReferences.Add($connRef)
-            }
-            #Custom Connector Variable Definition
-            elseif($solutioncomponent.componenttype_Property.Value.Value -eq 372 -and "$generateCustomConnectorConfig" -ne "false") {
-                  #"ConnectorShareWithGroupTeamConfiguration": [
-                  #{
-                  #  "connectorId": "b464e249-0bf7-48c0-8350-24476349bac1",
-                  #  "aadGroupTeamName": "#{connectorshare.b464e249-0bf7-48c0-8350-24476349bac1}#"
-                  #}
-                #]
-                $connectorResult =  Get-CrmRecord -conn $conn -EntityLogicalName connector -Id $solutionComponent.objectid -Fields displayname
-                $connectorSharingConfig = $null
-                $placeholdername = $connectorResult.displayname.replace(' ','') + '.' + $solutionComponent.objectid
-                #Create the flow sharing deployment settings
-                $sharingConfigVariable = "#{connector.teamname." + $placeholdername + "}#"
-                $connectorSharingConfig = [PSCustomObject]@{"solutionComponentName"=$connectorResult.name; "solutionComponentUniqueName"=$solutionComponent.objectid; "aadGroupTeamName"="$sharingConfigVariable"}
-                $configurationVariables.Add($sharingConfigVariable)
-                $customConnectorSharings.Add($connectorSharingConfig)
-            }
-
-            #Environment Variable Definition
-            elseif($solutioncomponent.componenttype_Property.Value.Value -eq 380 -and "$generateEnvironmentVariables" -ne "false") {
-                  #"EnvironmentVariables": [
-                  #{
-                  #  "SchemaName": "cat_ConnectorBaseUrl",
-                  #  "Value": "#{environmentvariable.cat_ConnectorBaseUrl}#"
-                  #},
-                  #{
-                  #  "SchemaName": "cat_ConnectorHostUrl",
-                  #  "Value": "#{environmentvariable.cat_ConnectorHostUrl}#"
-                  #}
-                #]
-                $envVarResult =  Get-CrmRecord -conn $conn -EntityLogicalName environmentvariabledefinition -Id $solutionComponent.objectid -Fields schemaname, type
-                $envVar = $null
-                $envVarName = $envVarResult.schemaname
-                $envVarConfigVariable = "#{environmentvariable." + $envVarName + "}#"
-                $envVar = [PSCustomObject]@{"SchemaName"="$envVarName"; "Value"="$envVarConfigVariable"}
-                if($envVarResult.type_Property.Value.Value -eq 100000005) {
-                    $secretEnvironmentVariables.Add($envVarName)
+        if($null -ne $configurationDataEnvironment -and $null -ne $configurationDataEnvironment.UserSettings) {
+            foreach($configurationVariable in $configurationDataEnvironment.UserSettings) {
+                $configurationVariableName = $configurationVariable.Name
+                $configurationVariableValue = $configurationVariable.Value
+                #Set connection reference variables
+                if($configurationVariableName.StartsWith("connectionreference.user.", "CurrentCultureIgnoreCase")) {
+                    $schemaName = $configurationVariableName -replace "connectionreference.user.", ""
+                    $connRefResults = Get-CrmRecords -conn $conn -EntityLogicalName connectionreference -FilterAttribute "connectionreferencelogicalname" -FilterOperator "eq" -FilterValue $schemaName -Fields connectorid
+                    if ($connRefResults.Count -gt 0){
+                        $connectorId = $connRefResults.CrmRecords[0].connectorid
+                        $connectionVariable = $configurationDataEnvironment.UserSettings | Where-Object { $_.Name -eq "connectionreference.$schemaName" } | Select-Object -First 1
+                        $connectionVariableName = $connectionVariable.Name
+                        $connectionVariableValue = $connectionVariable.Value
+                        if($null -ne $connectionVariable) {
+                            $connRef = [PSCustomObject]@{"LogicalName"="$schemaName"; "ConnectionId"="#{$connectionVariableName}#"; "ConnectorId"= "$connectorId"; "ConnectionOwner"="#{$configurationVariableName}#" }
+                            if($usePlaceholders.ToLower() -eq 'false') {
+                                $connRef = [PSCustomObject]@{"LogicalName"="$schemaName"; "ConnectionId"="$connectionVariableValue"; "ConnectorId"= "$connectorId"; "ConnectionOwner"="$configurationVariableValue" }
+                            }
+                            $connectionReferences.Add($connRef)
+                        }
+                    }
                 }
-                $configurationVariables.Add($envVarConfigVariable)
-                $environmentVariables.Add($envVar)
-            }
-            #Canvas App
-            elseif($solutioncomponent.componenttype_Property.Value.Value -eq 300 -and "$generateCanvasSharingConfig" -ne "false") {
-                #"AadGroupCanvasConfiguration": [
-                # {
-                #    "aadGroupId": "#{canvasshare.aadGroupId}#",
-                #    "canvasNameInSolution": "cat_devopskitsamplecanvasapp_c7ec5",
-                #    "canvasDisplayName": "cat_devopskitsamplecanvasapp_c7ec5",
-                #    "roleName": "#{canvasshare.roleName}#"
-                # }
-                #]
-                $canvasAppResult =  Get-CrmRecord -conn $conn -EntityLogicalName canvasapp -Id $solutionComponent.objectid -Fields solutionid, name, displayname
-                $canvasConfig = $null
-                $canvasName = $canvasAppResult.name
-                $aadGroupConfigVariable = "#{canvasshare.aadGroupId." + $canvasName + "}#"
-                $groupRoleConfigVariable = "#{canvasshare.roleName." + $canvasName + "}#"
-                $canvasConfig = [PSCustomObject]@{"aadGroupId"="$aadGroupConfigVariable"; "canvasNameInSolution"=$canvasName; "canvasDisplayName"= $canvasAppResult.displayname; "roleName"="$groupRoleConfigVariable"}
-                $configurationVariables.Add($aadGroupConfigVariable)
-                $configurationVariables.Add($groupRoleConfigVariable)
-                $canvasApps.Add($canvasConfig)
-            }
-            #Workflow
-            elseif($solutioncomponent.componenttype_Property.Value.Value -eq 29 -and "$generateFlowConfig" -ne "false") {
-                #"SolutionComponentOwnershipConfiguration": [
-                #{
-                #  "solutionComponentType": 29,
-                #  "solutionComponentUniqueName": "71cc728c-2487-eb11-a812-000d3a8fe6a3",
-                #  "solutionComponentName": My Flow,
-                #  "ownerEmail": "#{owner.ownerEmail}#"
-                #},
-                #{
-                #  "solutionComponentType": 29,
-                #  "solutionComponentUniqueName": "d2f7f0e2-a1a9-eb11-b1ac-000d3a53c3c2",
-                #  "solutionComponentName": My Other Flow,
-                #  "ownerEmail": "#{owner.ownerEmail}#"
-                #}
-                #]
-                $flowResult =  Get-CrmRecord -conn $conn -EntityLogicalName workflow -Id $solutionComponent.objectid -Fields solutionid, name
-                $flowConfig = $null
-                $flowActivationUserConfig = $null
-                $flowSharingConfig = $null
-                $workflowName = $solutionComponent.objectid
-                $placeholdername = $flowResult.name.replace(' ','') + '.' + $solutionComponent.objectid
-                $ownerConfigVariable = "#{owner.ownerEmail." + $placeholdername + "}#"
-                #Create the flow owner deployment settings
-                $flowConfig = [PSCustomObject]@{"solutionComponentType"=$solutioncomponent.componenttype_Property.Value.Value; "solutionComponentName"=$flowResult.name; "solutionComponentUniqueName"=$workflowName; "ownerEmail"="$ownerConfigVariable"}
-                $configurationVariables.Add($ownerConfigVariable)
-                $flowOwnerships.Add($flowConfig)
+                #Set environment variable variables
+                elseif($configurationVariableName.StartsWith("environmentvariable.", "CurrentCultureIgnoreCase")) {
+                    $schemaName = $configurationVariableName -replace "environmentvariable.", ""
+                    $envVarResults =  Get-CrmRecords -conn $conn -EntityLogicalName environmentvariabledefinition -FilterAttribute "schemaname" -FilterOperator "eq" -FilterValue $schemaName -Fields type
+                    if ($envVarResults.Count -gt 0){
+                        $type = $envVarResults.CrmRecords[0].type_Property.Value.Value
+                        if($type -ne 100000005 -or -not [string]::IsNullOrEmpty($configurationVariableValue)) {
+                            $envVar = [PSCustomObject]@{"SchemaName"="$schemaName"; "Value"="#{$configurationVariableName}#"}
+                            if($usePlaceholders.ToLower() -eq 'false') {
+                                $envVar = [PSCustomObject]@{"SchemaName"="$schemaName"; "Value"="$configurationVariableValue"}
+                            }
+                            $environmentVariables.Add($envVar)
+                        }
+                    }
+                }
+                elseif($configurationVariableName.StartsWith("canvasshare.aadGroupId.", "CurrentCultureIgnoreCase")) {
+                    $schemaName = $configurationVariableName -replace "canvasshare.aadGroupId.", ""
+                    $roleVariable = $configurationDataEnvironment.UserSettings | Where-Object { $_.Name -eq "canvasshare.roleName.$schemaName" } | Select-Object -First 1
+                    $canvasAppResults =  Get-CrmRecords -conn $conn -EntityLogicalName canvasapp -FilterAttribute "name" -FilterOperator "eq" -FilterValue $schemaName -Fields displayname
+                    if($canvasAppResults.Count -gt 0 -and $null -ne $roleVariable) {
+                        $canvasAppResult = $canvasAppResults.CrmRecords[0]
+                        $roleVariableName = $roleVariable.Name
+                        $roleVariableValue = $roleVariable.Value
+                        $canvasConfig = [PSCustomObject]@{"aadGroupId"="#{$configurationVariableName}#"; "canvasNameInSolution"=$schemaName; "canvasDisplayName"= $canvasAppResult.displayname; "roleName"="#{$roleVariableName}#"}
+                        if($usePlaceholders.ToLower() -eq 'false') {
+                            $canvasConfig = [PSCustomObject]@{"aadGroupId"="$configurationVariableValue"; "canvasNameInSolution"=$schemaName; "canvasDisplayName"= $canvasAppResult.displayname; "roleName"="$roleVariableValue"}
+                        }
+                        $canvasApps.Add($canvasConfig)
+                    }
+                }
+                elseif($configurationVariableName.StartsWith("owner.ownerEmail.", "CurrentCultureIgnoreCase")) {
+                    #Create the flow ownership deployment settings
+                    $flowSplit = $configurationVariableName.Split(".")
+                    if($flowSplit.length -eq 4){
+                        $flowOwnerConfig = [PSCustomObject]@{"solutionComponentType"=29; "solutionComponentName"=$flowSplit[2]; "solutionComponentUniqueName"=$flowSplit[3]; "ownerEmail"="#{$configurationVariableName}#"}
+                        if($usePlaceholders.ToLower() -eq 'false') {
+                            $flowOwnerConfig = [PSCustomObject]@{"solutionComponentType"=29; "solutionComponentName"=$flowSplit[2]; "solutionComponentUniqueName"=$flowSplit[3]; "ownerEmail"="$configurationVariableValue"}
+                        }
+                        $flowOwnerships.Add($flowOwnerConfig)
+                    }
+                }
+                elseif($configurationVariableName.StartsWith("flow.sharing.", "CurrentCultureIgnoreCase")) {
+                    $flowSplit = $configurationVariableName.Split(".")
+                    $flowSharing = [PSCustomObject]@{"solutionComponentName"=$flowSplit[2]; "solutionComponentUniqueName"=$flowSplit[3]; "aadGroupTeamName"="#{$configurationVariableName}#"}
+                    if($usePlaceholders.ToLower() -eq 'false') {
+                        $flowSharing = [PSCustomObject]@{"solutionComponentName"=$flowSplit[2]; "solutionComponentUniqueName"=$flowSplit[3]; "aadGroupTeamName"="$configurationVariableValue"}
+                    }
+                    $flowSharings.Add($flowSharing)
+                }
+                elseif($configurationVariableName.StartsWith("activateflow.activate.", "CurrentCultureIgnoreCase")) {
+                    $flowSplit = $configurationVariableName.Split(".")
+                    $flowActivateAsName = $configurationVariableName.Replace(".activate.", ".activateas.")
+                    $flowActivateOrderName = $configurationVariableName.Replace(".activate.", ".order.")
 
-                #Create the flow sharing deployment settings
-                $sharingConfigVariable = "#{flow.sharing." + $placeholdername + "}#"
-                $flowSharingConfig = [PSCustomObject]@{"solutionComponentName"=$flowResult.name; "solutionComponentUniqueName"=$workflowName; "aadGroupTeamName"="$sharingConfigVariable"}
-                $configurationVariables.Add($sharingConfigVariable)
-                $flowSharings.Add($flowSharingConfig)
+                    $flowActivateAs = $configurationDataEnvironment.UserSettings | Where-Object { $_.Name -eq $flowActivateAsName } | Select-Object -First 1
+                    $flowActivateOrder = $configurationDataEnvironment.UserSettings | Where-Object { $_.Name -eq $flowActivateOrderName } | Select-Object -First 1
 
-                #Create the flow activation user deployment settings
-                $sortOrderConfigVariable = "#{activateflow.order." + $placeholdername + "}#"
-                $activateConfigVariable = "#{activateflow.activate." + $placeholdername + "}#"
-                $activateUserConfigVariable = "#{activateflow.activateas." + $placeholdername + "}#"
-                $flowActivationUserConfig = [PSCustomObject]@{"solutionComponentName"=$flowResult.name; "solutionComponentUniqueName"=$workflowName; "activateAsUser"="$activateUserConfigVariable"; "sortOrder"="$sortOrderConfigVariable"; "activate"="$activateConfigVariable"}
-                $configurationVariables.Add($sortOrderConfigVariable)
-                $configurationVariables.Add($activateConfigVariable)
-                $configurationVariables.Add($activateUserConfigVariable)
-                $flowActivationUsers.Add($flowActivationUserConfig)
-            }
-        }
+                    if($null -ne $flowActivateAs -and $null -ne $flowActivateOrder) {
+                        $flowActivateOrderValue = $flowActivateOrder.Value
+                        $flowActivateAsValue = $flowActivateAs.Value
 
-        $newConfiguration = [PSCustomObject]@{}
-        $newConfiguration | Add-Member -MemberType NoteProperty -Name 'EnvironmentVariables' -Value $environmentVariables
-        $newConfiguration | Add-Member -MemberType NoteProperty -Name 'ConnectionReferences' -Value $connectionReferences
+                        $flowActivateConfig = [PSCustomObject]@{"solutionComponentName"=$flowSplit[2]; "solutionComponentUniqueName"=$flowSplit[3]; "activateAsUser"="#{$flowActivateAsName}#"; "sortOrder"="#{$flowActivateOrderName}#"; "activate"="#{$configurationVariableName}#"}
+                        if($usePlaceholders.ToLower() -eq 'false') {
+                            $flowActivateConfig = [PSCustomObject]@{"solutionComponentName"=$flowSplit[2]; "solutionComponentUniqueName"=$flowSplit[3]; "activateAsUser"="$flowActivateAsValue"; "sortOrder"="$flowActivateOrderValue"; "activate"="$configurationVariableValue"}
+                        }
+                        $flowActivationUsers.Add($flowActivateConfig)
+                    }
+                }
+                elseif($configurationVariableName.StartsWith("connector.teamname.", "CurrentCultureIgnoreCase")) {
+                    $connectorSplit = $configurationVariableName.Split(".")
+                    if($connectorSplit.length -eq 4){
+                        $connectorSharingConfig = [PSCustomObject]@{"solutionComponentName"=$connectorSplit[2]; "solutionComponentUniqueName"=$connectorSplit[3]; "aadGroupTeamName"="#{$configurationVariableName}#"}
+                        if($usePlaceholders.ToLower() -eq 'false') {
+                            $connectorSharingConfig = [PSCustomObject]@{"solutionComponentName"=$connectorSplit[2]; "solutionComponentUniqueName"=$connectorSplit[3]; "aadGroupTeamName"="$configurationVariableValue"}
+                        }
+                        $customConnectorSharings.Add($connectorSharingConfig)
+                    }
+                }
+                elseif($configurationVariableName.StartsWith("groupTeam.", "CurrentCultureIgnoreCase")) {
+                    $teamName = $configurationVariableName.split('.')[-1]
+                    $teamGroupRoles = $configurationVariable.Data.split(',')
 
-        $json = ConvertTo-Json -Depth 10 $newConfiguration
-        Set-Content -Path $deploymentSettingsFilePath -Value $json
-
-        $newCustomConfiguration = [PSCustomObject]@{}
-        $newCustomConfiguration | Add-Member -MemberType NoteProperty -Name 'ActivateFlowConfiguration' -Value $flowActivationUsers
-        $newCustomConfiguration | Add-Member -MemberType NoteProperty -Name 'ConnectorShareWithGroupTeamConfiguration' -Value $customConnectorSharings
-        $newCustomConfiguration | Add-Member -MemberType NoteProperty -Name 'SolutionComponentOwnershipConfiguration' -Value $flowOwnerships
-        $newCustomConfiguration | Add-Member -MemberType NoteProperty -Name 'FlowShareWithGroupTeamConfiguration' -Value $flowSharings
-        $newCustomConfiguration | Add-Member -MemberType NoteProperty -Name 'AadGroupCanvasConfiguration' -Value $canvasApps
-        $newCustomConfiguration | Add-Member -MemberType NoteProperty -Name 'AadGroupTeamConfiguration' -Value $groupTeams
-        #Convert the updated configuration to json and store in customDeploymentSettings.json
-        $json = ConvertTo-Json -Depth 10 $newCustomConfiguration
-        Set-Content -Path $customDeploymentSettingsFilePath -Value $json
-
-        #Update / Create Deployment Pipelines
-        New-DeploymentPipelines "$buildRepositoryName" "$orgUrl" "$projectName" "$repo" "$azdoAuthType" "$solutionName" $configurationData
-
-        $buildDefinitionResourceUrl = "$orgUrl$projectId/_apis/build/definitions?name=deploy-*-$solutionName&includeAllProperties=true&api-version=6.0"
-
-        $fullBuildDefinitionResponse = Invoke-RestMethod $buildDefinitionResourceUrl -Method Get -Headers @{
-            Authorization = "$azdoAuthType  $env:SYSTEM_ACCESSTOKEN"
-        }
-        $buildDefinitionResponseResults = $fullBuildDefinitionResponse.value
-
-        #Loop through the build definitions we found and update the pipeline variables based on the placeholders we put in the deployment settings files.
-        foreach($buildDefinitionResult in $buildDefinitionResponseResults)
-        {
-            #Getting the build definition id and variables to be updated
-            $definitionId = $buildDefinitionResult.id
-            $newBuildDefinitionVariables = $buildDefinitionResult.variables
-            #Loop through each of the tokens stored above and find an associated variable in the configuration data passed in from AA4AM
-
-            foreach($configurationVariable in $configurationVariables) {
-                $found = $false
-                $configurationVariable = $configurationVariable.replace('#{', '')
-                $configurationVariable = $configurationVariable.replace('}#', '')
+                    $groupTeamConfig = [PSCustomObject]@{"aadGroupTeamName"=$teamName; "aadSecurityGroupId"="#{$configurationVariableName}#"; "dataverseSecurityRoleNames"=@($teamGroupRoles)}
+                    if($usePlaceholders.ToLower() -eq 'false') {
+                        $groupTeamConfig = [PSCustomObject]@{"aadGroupTeamName"=$teamName; "aadSecurityGroupId"="$configurationVariableValue"; "dataverseSecurityRoleNames"=@($teamGroupRoles)}
+                    }
+                    $groupTeams.Add($groupTeamConfig)
+                }
 
                 #See if the variable already exists
+                $found = $false
                 foreach($buildVariable in $newBuildDefinitionVariables.PSObject.Properties) {
-                    if($buildVariable.Name -eq $configurationVariable) {
+                    if($buildVariable.Name -eq $configurationVariableName) {
                         $found = $true
                         break
                     }
-                }
-                #If the variable was not found create it 
-                if(!$found) {
-                    $newBuildDefinitionVariables | Add-Member -MemberType NoteProperty -Name $configurationVariable -Value @{value = ''}
-                }
-
-                if($configurationData.length -gt 0) {
-                    if($null -ne $configurationData) {
-                        $configurationDataEnvironment = $configurationData | Where-Object { $_.BuildName -eq $buildDefinitionResult.name } | Select-Object -First 1
-                        if($null -ne $configurationDataEnvironment -and $null -ne $configurationDataEnvironment.UserSettings) {
-                            $variable = $configurationDataEnvironment.UserSettings | Where-Object { $_.Name -eq $configurationVariable } | Select-Object -First 1
-                            # Set the value to the value passed in on the configuration data
-                            if($null -eq $variable -or $null -eq $variable.Value -or [string]::IsNullOrWhiteSpace($variable.Value)) {
-                                $newBuildDefinitionVariables.$configurationVariable.value = ''
-                            }
-                            else {
-                                $newBuildDefinitionVariables.$configurationVariable.value = $variable.Value
-                            }
-                        }
+                }                
+                #Add the configuration variable to the list of pipeline variables if usePlaceholders is not false
+                if($usePlaceholders.ToLower() -ne 'false') {
+                    #If the variable was not found create it 
+                    if(!$found) { 
+                        $newBuildDefinitionVariables | Add-Member -MemberType NoteProperty -Name $configurationVariableName -Value @{value = ''}
                     }
+
+                    # Set the value to the value passed in on the configuration data
+                    if($null -eq $configurationVariableValue -or [string]::IsNullOrWhiteSpace($configurationVariableValue)) {
+                        $newBuildDefinitionVariables.$configurationVariableName.value = ''
+                    } else {
+                        $newBuildDefinitionVariables.$configurationVariableName.value = $configurationVariableValue
+                    }
+                }
+                elseif($reservedVariables -contains $configurationVariableName) {
+                    #If the variable is in the reserved variables list then set the value to the value passed in on the configuration data
+                    if(!$found) { 
+                        $newBuildDefinitionVariables | Add-Member -MemberType NoteProperty -Name $configurationVariableName -Value @{value = ''}
+                    }
+                    $newBuildDefinitionVariables.$configurationVariableName.value = $configurationVariableValue
                 }
             }
 
-            $buildName = $buildDefinitionResult.name.ToLower()
-            # Declare Solution Upgrade Tags; By default is 'update'
-            $solutionUpgradeInputValue = $false
-            $pipelineVariableName =  "TriggerSolutionUpgrade"
-            if($null -ne $configurationData) 
-            {
-                foreach($deploymentEnvironment in $configurationData) 
-                {
-                    $deploymentBuildName = $deploymentEnvironment.BuildName.ToLower()
-                    if($deploymentBuildName -eq $buildName)
-                    {
-                        $solutionUpgradeTag = $deploymentEnvironment.UserSettings | Where-Object { $_.Name -eq $pipelineVariableName }
-                        if($null -ne $solutionUpgradeTag -and $null -ne $solutionUpgradeTag.Value)
-                        {
-                            if($solutionUpgradeTag.Value -eq "true")
-                            {
-                                $solutionUpgradeInputValue = $true
-                            }
-                            Write-Host "solutionUpgradeInputValue for  $deploymentBuildName - $solutionUpgradeInputValue"
-
-                            $found = $false
-                            #See if the variable already exists
-                            foreach($buildVariable in $newBuildDefinitionVariables.PSObject.Properties) {
-                                if($buildVariable.Name -eq $pipelineVariableName) {
-                                    $found = $true
-                                    break
-                                }
-                            }
-                            #If the variable was not found create it 
-                            if(!$found) {
-                                $newBuildDefinitionVariables | Add-Member -MemberType NoteProperty -Name $pipelineVariableName -Value @{value = ''}
-                            }
-                            # Set the value to the value passed in on the configuration data
-                            $newBuildDefinitionVariables.$pipelineVariableName.value = $solutionUpgradeInputValue
-                        }
-                     break;
-                    }
-                }
+            $environmentName = $configurationDataEnvironment.DeploymentEnvironmentName
+            if(Test-Path "$buildSourceDirectory\$repo\$solutionName\config\$environmentName\") {
+                Remove-Item -Path "$buildSourceDirectory\$repo\$solutionName\config\$environmentName\*eploymentSettings.json" -Force
+            }
+            else {
+                New-Item "$buildSourceDirectory\$repo\$solutionName\config" -Name "$environmentName" -ItemType "directory"
             }
 
+            #Create the deployment configuration
+            $deploymentSettingsFilePath = "$buildSourceDirectory\$repo\$solutionName\config\$environmentName\deploymentSettings.json"
+            $newConfiguration = [PSCustomObject]@{}
+            $newConfiguration | Add-Member -MemberType NoteProperty -Name 'EnvironmentVariables' -Value $environmentVariables
+            $newConfiguration | Add-Member -MemberType NoteProperty -Name 'ConnectionReferences' -Value $connectionReferences
+
+            $json = ConvertTo-Json -Depth 10 $newConfiguration
+            Set-Content -Path $deploymentSettingsFilePath -Value $json
+
+            #Create the custom deployment configuration
+            $customDeploymentSettingsFilePath = "$buildSourceDirectory\$repo\$solutionName\config\$environmentName\customDeploymentSettings.json"
+            $newCustomConfiguration = [PSCustomObject]@{}
+            $newCustomConfiguration | Add-Member -MemberType NoteProperty -Name 'ActivateFlowConfiguration' -Value $flowActivationUsers
+            $newCustomConfiguration | Add-Member -MemberType NoteProperty -Name 'ConnectorShareWithGroupTeamConfiguration' -Value $customConnectorSharings
+            $newCustomConfiguration | Add-Member -MemberType NoteProperty -Name 'SolutionComponentOwnershipConfiguration' -Value $flowOwnerships
+            $newCustomConfiguration | Add-Member -MemberType NoteProperty -Name 'FlowShareWithGroupTeamConfiguration' -Value $flowSharings
+            $newCustomConfiguration | Add-Member -MemberType NoteProperty -Name 'AadGroupCanvasConfiguration' -Value $canvasApps
+            $newCustomConfiguration | Add-Member -MemberType NoteProperty -Name 'AadGroupTeamConfiguration' -Value $groupTeams
+            #Convert the updated configuration to json and store in customDeploymentSettings.json
+            $json = ConvertTo-Json -Depth 10 $newCustomConfiguration
+            Set-Content -Path $customDeploymentSettingsFilePath -Value $json
+
+            #Set the build variables
             Set-BuildDefinitionVariables $orgUrl $projectId $azdoAuthType $buildDefinitionResult $definitionId $newBuildDefinitionVariables
         }
-        Set-EnvironmentDeploymentSettingsConfiguration $buildSourceDirectory $repo $solutionName $newConfiguration $newCustomConfiguration $configurationData $secretEnvironmentVariables
     }
 }
 
@@ -330,11 +262,11 @@ function New-DeploymentPipelines
 
         if($buildDefinitionResponseResults.length -lt $configurationData.length) {
             $currentPath = Get-Location
-            if(Test-Path -Path "../coe-starter-kit-source") {
-                Remove-Item "../coe-starter-kit-source" -Force -Recurse
+            if(Test-Path -Path "../cli") {
+                Remove-Item "../cli" -Force -Recurse
             }
-            New-Item -ItemType "directory" -Name "../coe-starter-kit-source"
-            Set-Location ../coe-starter-kit-source
+            New-Item -ItemType "directory" -Name "../cli"
+            Set-Location ../cli
             git clone -b "main" "https://github.com/microsoft/coe-starter-kit.git"
             Set-Location coe-starter-kit\coe-cli
             npm install
@@ -350,14 +282,12 @@ function New-DeploymentPipelines
                     $settings = $settings + $deploymentEnvironment.DeploymentEnvironmentName.ToLower() + "=" + $deploymentEnvironment.DeploymentEnvironmentUrl
                 }
 
-
                 if(-Not [string]::IsNullOrWhiteSpace($deploymentEnvironment.ServiceConnectionName) -and -Not [string]::IsNullOrWhiteSpace($deploymentEnvironment.DeploymentEnvironmentName)) {
                     if(-Not [string]::IsNullOrWhiteSpace($settings)) {
                         $settings = $settings + ","
                     }
                     $settings = $settings + $deploymentEnvironment.DeploymentEnvironmentName.ToLower() + "-scname=" + $deploymentEnvironment.ServiceConnectionName
                 }
-
 
                 if(-Not [string]::IsNullOrWhiteSpace($deploymentEnvironment.TenantId) -and -Not [string]::IsNullOrWhiteSpace($deploymentEnvironment.DeploymentEnvironmentName)) {
                     if(-Not [string]::IsNullOrWhiteSpace($settings)) {
@@ -367,11 +297,10 @@ function New-DeploymentPipelines
                     $settings = $settings + $deploymentEnvironment.DeploymentEnvironmentName.ToLower() + "-tenantid=" + $deploymentEnvironment.TenantId
                 }
 
-
                 if(-Not [string]::IsNullOrWhiteSpace($deploymentEnvironment.ClientId) -and -Not [string]::IsNullOrWhiteSpace($deploymentEnvironment.DeploymentEnvironmentName)) {
                     if(-Not [string]::IsNullOrWhiteSpace($settings)) {
                         $settings = $settings + ","
-                }
+                    }
                     $settings = $settings + $deploymentEnvironment.DeploymentEnvironmentName.ToLower() + "-clientid=" + $deploymentEnvironment.ClientId
                 }
 
@@ -385,11 +314,9 @@ function New-DeploymentPipelines
                 if(-Not [string]::IsNullOrWhiteSpace($deploymentEnvironment.VariableGroup) -and -Not [string]::IsNullOrWhiteSpace($deploymentEnvironment.DeploymentEnvironmentName)) {
                     if(-Not [string]::IsNullOrWhiteSpace($settings)) {
                         $settings = $settings + ","
-                }
+                    }
                     $settings = $settings + $deploymentEnvironment.DeploymentEnvironmentName.ToLower() + "-variablegroup=" + $deploymentEnvironment.VariableGroup
                 }
-
-
             }
             if(-Not [string]::IsNullOrWhiteSpace($settings)) {
                 Write-Host "Environments: " $settings
@@ -420,76 +347,4 @@ function Set-BuildDefinitionVariables {
     #remove tab charcters from the body
     $body = $body -replace "`t", ""
     Invoke-RestMethod $buildDefinitionResourceUrl -Method 'PUT' -Headers $headers -Body ([System.Text.Encoding]::UTF8.GetBytes($body)) | Out-Null   
-}
-
-function Set-EnvironmentDeploymentSettingsConfiguration {
-    param (
-        [Parameter(Mandatory)] [String]$buildSourceDirectory,
-        [Parameter(Mandatory)] [String]$repo,
-        [Parameter(Mandatory)] [String]$solutionName,
-        [Parameter()] [PSCustomObject]$newConfiguration,
-        [Parameter()] [PSCustomObject]$newCustomConfiguration,
-        [Parameter()] [PSCustomObject]$configurationData,
-        [Parameter()] [PSCustomObject]$secretEnvironmentVariables
-    )
-    foreach($newEnvironmentConfig in $configurationData) {
-        $groupTeams = [System.Collections.ArrayList]@()
-        $secretsRemoved = [System.Collections.ArrayList]@()
-        $environmentName = $newEnvironmentConfig.DeploymentEnvironmentName
-        if(-Not [string]::IsNullOrWhiteSpace($environmentName)) {
-            if(Test-Path "$buildSourceDirectory\$repo\$solutionName\config\$environmentName\") {
-                Remove-Item -Path "$buildSourceDirectory\$repo\$solutionName\config\$environmentName\*eploymentSettings.json" -Force
-            }
-        }
-        foreach($variableConfiguration in $newEnvironmentConfig.UserSettings) {
-            $variableName = $variableConfiguration.Name
-            if($variableName.Contains("groupTeam.")) {
-                $teamGroupConfigVariable = "#{$variableName}#"
-
-                $teamName = $variableConfiguration.Name.split('.')[-1]
-                $teamGroupRoles = $variableConfiguration.Data.split(',')
-
-                $groupTeamConfig = [PSCustomObject]@{"aadGroupTeamName"=$teamName; "aadSecurityGroupId"="$teamGroupConfigVariable"; "dataverseSecurityRoleNames"=@($teamGroupRoles)}
-                $configurationVariables.Add($teamGroupConfigVariable)
-                $groupTeams.Add($groupTeamConfig)
-            }
-        }
-
-        $secretsRemoved = $false
-        foreach($secretVariable in $secretEnvironmentVariables) {
-            $variable = $newEnvironmentConfig.UserSettings | Where-Object { $_.Name.Contains($secretVariable) } | Select-Object -First 1
-            if($null -eq $variable -or $null -eq $variable.Value -or $variable.Value -eq "") {
-
-                $configVariable = $newConfiguration.EnvironmentVariables | Where-Object { $_.SchemaName -eq $secretVariable } | Select-Object -First 1
-                $newConfiguration.EnvironmentVariables.Remove($configVariable)
-                $secretsRemoved = $true
-            }
-        }
-
-
-        if(-Not [string]::IsNullOrWhiteSpace($environmentName)) {
-            ([pscustomobject]$newCustomConfiguration.AadGroupTeamConfiguration) = $groupTeams
-            if($groupTeams.Count -gt 0) {
-                if(!(Test-Path "$buildSourceDirectory\$repo\$solutionName\config\$environmentName")) {
-                    New-Item "$buildSourceDirectory\$repo\$solutionName\config" -Name "$environmentName" -ItemType "directory"
-                }
-
-                #Convert the updated configuration to json and store in customDeploymentSettings.json
-                $json = ConvertTo-Json -Depth 10 ([pscustomobject]$newCustomConfiguration)
-                Set-Content -Path "$buildSourceDirectory\$repo\$solutionName\config\$environmentName\customDeploymentSettings.json" -Value $json
-            }
-            Write-Host "Checking for secrets removed"
-            if($secretsRemoved) {
-                Write-Host "Secrets removed creating deploymentConfiguration for $environmentName"
-                if(!(Test-Path "$buildSourceDirectory\$repo\$solutionName\config\$environmentName")) {
-                    New-Item "$buildSourceDirectory\$repo\$solutionName\config" -Name "$environmentName" -ItemType "directory"
-                }
-
-                #Convert the updated configuration to json and store in customDeploymentSettings.json
-                $json = ConvertTo-Json -Depth 10 $newConfiguration
-                Set-Content -Path "$buildSourceDirectory\$repo\$solutionName\config\$environmentName\deploymentSettings.json" -Value $json
-
-            }
-        }
-    }
 }


### PR DESCRIPTION
Fixes microsoft/coe-starter-kit#3448
Updating update-deployment-settings.ps1 to loop over all variables passed in on the json payload rather than pulling solution components unnecessarily. This will make the deployment settings payload more extensible going forward but also makes it possible to pass in multiple canvassharing configurations for the same canvas app.