### PR TITLE
Fix for release testing feedback

### DIFF
--- a/Pipelines/Templates/update-deployment-settings.yml
+++ b/Pipelines/Templates/update-deployment-settings.yml
@@ -29,11 +29,10 @@ steps:
       # Parsing this could be brittle and have side effects so we've included the ability to set variables to override this parsing (i.e. PipelineProject and PipelineRepository)
       # These can be set as global variables in the alm-accelerator-variable-group.
 
-      #Default to pipeline project and repo
+      #Default to pipeline project and repo to the project where the pipeline is running and the and repo of this yaml
       $pipelineProject = "$(System.TeamProject)"
       $pipelineRepo = "$(Build.Repository.Name)"
 
-      $repoUri = 
       $segments = ([System.Uri]"$(Build.Repository.Uri)").LocalPath.Split("/")
 
       #Use the parsed value from the repo uri if it follows the expected format

--- a/Pipelines/Templates/update-deployment-settings.yml
+++ b/Pipelines/Templates/update-deployment-settings.yml
@@ -20,13 +20,32 @@ steps:
       # load PowerShell files into memory
       . "$env:POWERSHELLPATH/update-deployment-settings.ps1"
 
-      #Check to see if pipeline project and repo have been overridden
+      # We need the project and repository where the yaml for this pipeline exists. Unfortunately, there's no way to get this directly from any of the available 
+      # predefined variables. We can get the repository name from $(Build.Repository.Name). However, there's no similar variable for the project name associated 
+      # with the repository as $(System.TeamProject) refers to where the pipeline that consumes this YAML was created. In the case that the pipelines are hosted in
+      # another project the only way to get both of these is to parse $(Build.Repository.Uri) which has both the project and repo name.
+      #Name  : $(Build.Repository.Uri)
+      #Value : https://[ORGNAME]@dev.azure.com/[ORGNAME]/[PROJECTNAME]/_git/[REPONAME]
+      # Parsing this could be brittle and have side effects so we've included the ability to set variables to override this parsing (i.e. PipelineProject and PipelineRepository)
+      # These can be set as global variables in the alm-accelerator-variable-group.
+
+      #Default to pipeline project and repo
       $pipelineProject = "$(System.TeamProject)"
+      $pipelineRepo = "$(Build.Repository.Name)"
+
+      $repoUri = 
+      $segments = ([System.Uri]"$(Build.Repository.Uri)").LocalPath.Split("/")
+
+      #Use the parsed value from the repo uri if it follows the expected format
+      if($segments.Length -gt 3) {
+        $pipelineProject = $segments[2]
+        $pipelineRepo = $segments[4]
+      }
+
+      #Finally, use the override variables to bypass the options above
       if(!'$(PipelineProject)'.Contains("PipelineProject")) {
         $pipelineProject = "$(PipelineProject)"
       }
-
-      $pipelineRepo = "$(Build.Repository.Name)"
       if(!'$(PipelineRepository)'.Contains("PipelineRepository")) {
         $pipelineRepo = "$(PipelineRepository)"
       }


### PR DESCRIPTION
Fix for using seperate project for pipeline templates and export pipeline. @rsantos00 this is related to our discussion of your testing feedback this morning. We can talk more about it Friday AM as I've made another discovery here related to the experience in app that shouldn't require us to make any changes to the app but does warrant some documentation.