### PR TITLE
Infer Pipelines Project and repo-name from Pre-defined variables

### DIFF
--- a/Pipelines/Templates/update-deployment-settings.yml
+++ b/Pipelines/Templates/update-deployment-settings.yml
@@ -24,24 +24,16 @@ steps:
       # predefined variables. We can get the repository name from $(Build.Repository.Name). However, there's no similar variable for the project name associated 
       # with the repository as $(System.TeamProject) refers to where the pipeline that consumes this YAML was created. In the case that the pipelines are hosted in
       # another project the only way to get both of these is to parse $(Build.Repository.Uri) which has both the project and repo name.
-      #Name  : $(Build.Repository.Uri)
-      #Value : https://[ORGNAME]@dev.azure.com/[ORGNAME]/[PROJECTNAME]/_git/[REPONAME]
-      # Parsing this could be brittle and have side effects so we've included the ability to set variables to override this parsing (i.e. PipelineProject and PipelineRepository)
+      # Name  : $(Build.Repository.Uri)
+      # Value : https://[ORGNAME]@dev.azure.com/[ORGNAME]/[PROJECTNAME]/_git/[REPONAME]
+      # We've included the ability to set variables to override this parsing (i.e. PipelineProject and PipelineRepository)
       # These can be set as global variables in the alm-accelerator-variable-group.
 
-      #Default to pipeline project and repo to the project where the pipeline is running and the and repo of this yaml
+      # Default to pipeline project and repo to the project where the pipeline is running and the and repo of this yaml
       $pipelineProject = "$(System.TeamProject)"
       $pipelineRepo = "$(Build.Repository.Name)"
 
-      $segments = ([System.Uri]"$(Build.Repository.Uri)").LocalPath.Split("/")
-
-      #Use the parsed value from the repo uri if it follows the expected format
-      if($segments.Length -gt 3) {
-        $pipelineProject = $segments[2]
-        $pipelineRepo = $segments[4]
-      }
-
-      #Finally, use the override variables to bypass the options above
+      # Use the override variables to bypass the options above
       if(!'$(PipelineProject)'.Contains("PipelineProject")) {
         $pipelineProject = "$(PipelineProject)"
       }

--- a/Pipelines/Templates/update-deployment-settings.yml
+++ b/Pipelines/Templates/update-deployment-settings.yml
@@ -34,10 +34,10 @@ steps:
       $pipelineRepo = "$(Build.Repository.Name)"
 
       # Use the override variables to bypass the options above
-      if(!'$(PipelineProject)'.Contains("PipelineProject")) {
+      if(!'$(PipelineProject)'.StartsWith("`$(")) {
         $pipelineProject = "$(PipelineProject)"
       }
-      if(!'$(PipelineRepository)'.Contains("PipelineRepository")) {
+      if(!'$(PipelineRepository)'.StartsWith("`$(")) {
         $pipelineRepo = "$(PipelineRepository)"
       }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/coe-starter-kit/issues/3538

The assumptions stated in the comment shown below turns out to be false. There is no issue when using `$(System.TeamProject)` as the value is correct when the pipeline run. Even if the pipeline repo is located in the different project than the target repository of the solution, the pipeline still executes the pipeline-yaml from the selected pipelines-repo. In other words: the magic repository resource `self` in this pipeline will always be the `pipelineProject/pipeline-repo`, therefore `$(System.TeamProject)` will yield the correct project name.

https://github.com/microsoft/coe-alm-accelerator-templates/blob/db8ca5df01275cb366807d030b91d722de46cf07/Pipelines/Templates/update-deployment-settings.yml#L23-L30