### PR TITLE
Enforce writing JSON files using UTF8 No BOM encoding

### DIFF
--- a/Pipelines/Templates/build-Solution.yml
+++ b/Pipelines/Templates/build-Solution.yml
@@ -91,7 +91,7 @@ steps:
     ForEach-Object {
         $fileContent = (Get-Content $_.FullName) -join ' '
         if(-not [string]::IsNullOrWhiteSpace($fileContent)) {
-            Set-Content $_.FullName $fileContent
+            Set-Content $_.FullName $fileContent -Encoding utf8NoBOM
         }
     }
   displayName: 'Flatten JSON files'

--- a/Pipelines/Templates/export-Solution.yml
+++ b/Pipelines/Templates/export-Solution.yml
@@ -228,7 +228,7 @@ steps:
      if(-not $_.FullName.Contains('CanvasApps') -and -not $_.FullName.Contains('Workflows')) {
        Write-Host $_.FullName
        $formatted = jq . $_.FullName --sort-keys
-       $formatted | Out-File $_.FullName -Encoding UTF8
+       $formatted | Out-File $_.FullName -Encoding utf8NoBOM
      }
    }
   displayName: 'Format JSON files'

--- a/Pipelines/Templates/set-deployment-variable.yml
+++ b/Pipelines/Templates/set-deployment-variable.yml
@@ -27,7 +27,7 @@ steps:
                 }
                 Write-Host "Writing to file $variableValue"
                 Write-Host $settingsJson
-                $settingsJson | Out-File $variableValue
+                $settingsJson | Out-File $variableValue -Encoding utf8NoBOM
             }
         }
     }

--- a/PowerShell/build-test-automation-urls.ps1
+++ b/PowerShell/build-test-automation-urls.ps1
@@ -48,7 +48,14 @@ function Set-CanvasTestAutomationURLs {
         }
     }
     $json = ConvertTo-Json $testUrlsObject
-    Set-Content -Path "CanvasTestAutomationURLs.json" -Value $json -Force
+    if ($PSVersionTable.PSVersion.Major -gt 5) {
+        Set-Content -Path "CanvasTestAutomationURLs.json" -Value $json -Force -Encoding utf8NoBOM
+    }
+    else {
+        $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $false
+        $jsonBytes = $utf8NoBomEncoding.GetBytes($json)
+        Set-Content -Path "CanvasTestAutomationURLs.json" -Value $jsonBytes -Encoding Byte
+    }
     Get-Content -Path "CanvasTestAutomationURLs.json"
 }
 

--- a/PowerShell/load-save-pipeline-parameters.ps1
+++ b/PowerShell/load-save-pipeline-parameters.ps1
@@ -56,7 +56,16 @@ function Write-Pipeline-Parameters {
     if (Test-Path $filePath) {
         Remove-Item $filePath
     }
-    $pipelineParameterObject | ConvertTo-Json -depth 100 | Out-File "$filePath"
+    [string]$pipelineParameterJson = $pipelineParameterObject | ConvertTo-Json -depth 100
+    if ($PSVersionTable.PSVersion.Major -gt 5) {
+        $pipelineParameterJson | Out-File "$filePath" -Encoding utf8NoBOM
+    }
+    else {
+        $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $false
+        [System.IO.File]::WriteAllText($filePath, $pipelineParameterJson, $utf8NoBomEncoding)
+        # PowerShell < v6 does not support writing UTF8 without BOM using Out-File
+        # $pipelineParameterJson | Out-File "$filePath"
+    }
 }
 function Read-Pipeline-Parameters {
     param (

--- a/PowerShell/tests/utilities.tests.ps1
+++ b/PowerShell/tests/utilities.tests.ps1
@@ -14,7 +14,15 @@ function Invoke-SetDeploymentVariable
             if(Test-Path -Path "$deploymentSettingsNode.json") {
                 Remove-Item -Path "$deploymentSettingsNode.json" -Force
             }
-            $settingsJson | Out-File "$deploymentSettingsNode.json"
+            if ($PSVersionTable.PSVersion.Major -gt 5) {
+                $settingsJson | Out-File "$deploymentSettingsNode.json" -Encoding utf8NoBOM
+            }
+            else {
+                $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $false
+                [System.IO.File]::WriteAllText("$deploymentSettingsNode.json", $settingsJson, $utf8NoBomEncoding)
+                # PowerShell < v6 does not support writing UTF8 without BOM using Out-File
+                # $settingsJson | Out-File "$deploymentSettingsNode.json"
+            }
 
             return "$deploymentSettingsNode.json"
         }

--- a/PowerShell/update-deployment-settings.ps1
+++ b/PowerShell/update-deployment-settings.ps1
@@ -238,7 +238,14 @@
 
             Write-Host "Creating deployment settings"
             $json = ConvertTo-Json -Depth 10 $newConfiguration
-            Set-Content -Path $deploymentSettingsFilePath -Value $json
+            if ($PSVersionTable.PSVersion.Major -gt 5) {
+                Set-Content -Path $deploymentSettingsFilePath -Value $json
+            }
+            else {
+                $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $false
+                $jsonBytes = $utf8NoBomEncoding.GetBytes($json)
+                Set-Content -Path $deploymentSettingsFilePath -Value $jsonBytes -Encoding Byte
+            }
 
             #Create the custom deployment configuration
             $customDeploymentSettingsFilePath = "$buildSourceDirectory\$repo\$solutionName\config\$environmentName\customDeploymentSettings.json"
@@ -252,8 +259,14 @@
             #Convert the updated configuration to json and store in customDeploymentSettings.json
             Write-Host "Creating custom deployment settings"
             $json = ConvertTo-Json -Depth 10 $newCustomConfiguration
-            Set-Content -Path $customDeploymentSettingsFilePath -Value $json
-
+            if ($PSVersionTable.PSVersion.Major -gt 5) {
+                Set-Content -Path $customDeploymentSettingsFilePath -Value $json
+            }
+            else {
+                $utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $false
+                $jsonBytes = $utf8NoBomEncoding.GetBytes($json)
+                Set-Content -Path $customDeploymentSettingsFilePath -Value $jsonBytes -Encoding Byte
+            }
             #Set the build variables
             Set-BuildDefinitionVariables $orgUrl $projectName $azdoAuthType $buildDefinitionResponseResults[0] $buildDefinitionResponseResults[0].id $newBuildDefinitionVariables
         }


### PR DESCRIPTION
fixes https://github.com/microsoft/coe-starter-kit/issues/3717

By default PowerShell will write out files using ANSI settings which for Azure Pipelines agents means `windows-1252` encoding. JSON files should always be written using UTF-8 encoding without BOM.

Generally in PowerShell we use either the `Set-Content` or `Out-File` commandlets.

In PowerShell version 6 (i.e. PowerShell Core) or greater the fix is easy, both `Out-File` and `Set-Content` recognize `-Encoding utf8NoBOM`.

In PowerShell version 5 (i.e. Windows PowerShell) the fix is a little bit more tricky:  
For both commandlets you have to start with creating a `UTF8Encoding` instance setting the `.ctor` argument for BOM to `false`.  
`Set-Content` supports `-Encoding Byte`. So the easiest way is to use the `UTF8Encoding` instance to get the bytes and then pass these in to `Set-Content` using the Byte encoding.  
`Out-File` does not even recognize `Byte` encoding. Therefore, the easiest way to fix it is replacing the `Out-File` call with a static .NET `System.IO.File.Write*` method invocation. This is equivalent in this repo, since all `Out-File` calls write to a real file on the local file system (no cross-PSHost invocations or special file types).