### PR TITLE
Fix for pac cli 1.19.4 Sync issue. (#224)

### DIFF
--- a/PowerShell/code-first-functions.ps1
+++ b/PowerShell/code-first-functions.ps1
@@ -212,7 +212,10 @@ function clone-or-sync-solution{
         if(Test-Path "$cdsProjPath")
         {
             Write-Host "Cloned solution available; Triggering Solution Sync"
-            $syncCommand = "solution sync -pca true -f ""$cdsProjFolderPath"" -p Both"
+            $cdsProjfolderPath = [System.IO.Path]::GetDirectoryName("$cdsProjPath")
+            Write-Host "Pointing to cdsproj folder path - " $cdsProjfolderPath
+            Set-Location -Path $cdsProjfolderPath
+            $syncCommand = "solution sync -pca true -p Both"
             Write-Host "Triggering Sync - $syncCommand"
             Invoke-Expression -Command "$pacexepath $syncCommand"
         }
@@ -328,7 +331,6 @@ function restructure-legacy-folders{
         Write-Host "temp_cdsProjPath - $temp_cdsProjPath"
         if(Test-Path "$temp_cdsProjPath")
         {
-            #Copy-Item "$temp_cdsProjPath" -Destination "$buildSourceDirectory\$repo\$solutionName\SolutionPackage\$solutionName\"
             Copy-Item "$temp_cdsProjPath" -Destination "$buildSourceDirectory\$repo\$solutionName\SolutionPackage\"
             Write-Host "Adding Package Type 'Both' to .cds proj file"
             add-packagetype-node-to-cdsproj "$buildSourceDirectory" "$repo" "$solutionName"


### PR DESCRIPTION
* Fix for pac cli 1.19.4 Sync issue. Instead of using --solution-folder pointing the cmd to .csproj root folder.

* Deleted commented code