### PR TITLE
Use same version handling logic during build as during export

### DIFF
--- a/Pipelines/Templates/build-Solution.yml
+++ b/Pipelines/Templates/build-Solution.yml
@@ -72,13 +72,25 @@ steps:
       restructure-legacy-folders '$(Build.ArtifactStagingDirectory)' '$(Build.SourcesDirectory)' '$(RepoName)' '${{parameters.solutionName}}' '$(pacPath)' '${{parameters.serviceConnectionUrl}}' '$(Agent.BuildDirectory)'
   displayName: 'Restructure legacy folders'
   
-# Solution version in source control is not used.  Instead, create version at build time from the current build number.
+  # By default variable UseSolutionVersionFromDataverse is not 'true'
+  # use pipeline build number for versioning
 - pwsh: |
    $solutionXMLPath = "$(Build.SourcesDirectory)\$(RepoName)\${{parameters.solutionName}}\SolutionPackage\src\Other\Solution.xml"
     . "$env:POWERSHELLPATH/build-deploy-solution-functions.ps1"
    update-solution-xml-with-build-number "$solutionXMLPath" "$(Build.BuildNumber)"
   displayName: 'Update Solution XML with Build Number'
-  condition: and(succeeded(), ne('${{parameters.buildType}}', 'Unmanaged'))
+  condition: and(succeeded(), ne(variables.UseSolutionVersionFromDataverse, 'true'))
+
+  # If UseSolutionVersionFromDataverse is 'true'
+  # use version number from solution xml for pipeline build number
+  # Updating the Pipeline Build number is only useful for display purposes
+- pwsh: |
+    $solutionXMLPath = "$(Build.SourcesDirectory)\$(RepoName)\${{parameters.solutionName}}\SolutionPackage\src\Other\Solution.xml"
+    [xml]$solutionXmlDoc = Get-Content -LiteralPath $solutionXMLPath
+    Write-Host "##vso[build.updatebuildnumber]$($solutionXmlDoc.ImportExportXml.SolutionManifest.Version)"
+  displayName: 'Update Build Number from Solution XML'
+  condition: and(succeeded(), eq(variables.UseSolutionVersionFromDataverse, 'true'))
+
 
 # Before we committed changes, we formatted all json files for readability in source control.  This breaks solution package, so we need to flatten them before packing   
 - pwsh: |


### PR DESCRIPTION
## TL;DR 

With this PR, if the override variable `UseSolutionVersionFromDataverse` is `'true'` the build number in the `build-deploy-*-SampleSolution.yml` is ignored and the version number in `Solution.xml` becomes authorative in all situations.

## Current behaviour

When exporting a solution to git the pipeline uses a variable `UseSolutionVersionFromDataverse` to determine whether the version number coming from Dataverse should be cleared in the `Solution.xml` file. By default the variable is not defined in the ALM variable group and therefore, the default behaviour is to clear the version number.

However, during build there is a different logic: When the solution is built `'Unmanaged'` (which only happens during `import-unmanaged-solution.yml`) the version number is taken from the `Solution.xml` and in all other cases it is taken from the pipeline build number.

## Proposed change

I propose that the logic should be the same for both exporting and deployment. I have modified the conditional for the clearing step in `build-solution.yml` to align with the conditional in `export-solution.yml`. As a bonus, I added an additional step that updates the Pipeline build number from the solution XML for the opposite condition. That is not strictly necessary, but the pipeline build number is shown in Azure DevOps and I thought it might be helpful if the version number deployed matches the one displayed in DevOps.

