### PR TITLE
Include Solution Unique name when updating pipeline BuildNumber

### DIFF
--- a/Pipelines/Templates/build-Solution.yml
+++ b/Pipelines/Templates/build-Solution.yml
@@ -78,26 +78,17 @@ steps:
     . "$env:POWERSHELLPATH/build-deploy-solution-functions.ps1"
    update-solution-xml-with-build-number "$solutionXMLPath" "$(Build.BuildNumber)"
   displayName: 'Update Solution XML with Build Number'
-  condition: and(succeeded(), ne('${{parameters.buildType}}', 'Unmanaged'))
+  condition: and(succeeded(), ne(variables.UseSolutionVersionFromDataverse, 'true'))
   
-#  # By default variable UseSolutionVersionFromDataverse is not 'true'
-#  # use pipeline build number for versioning
-#- pwsh: |
-#   $solutionXMLPath = "$(Build.SourcesDirectory)\$(RepoName)\${{parameters.solutionName}}\SolutionPackage\src\Other\Solution.xml"
-#    . "$env:POWERSHELLPATH/build-deploy-solution-functions.ps1"
-#   update-solution-xml-with-build-number "$solutionXMLPath" "$(Build.BuildNumber)"
-#  displayName: 'Update Solution XML with Build Number'
-#  condition: and(succeeded(), ne(variables.UseSolutionVersionFromDataverse, 'true'))
-
-#  # If UseSolutionVersionFromDataverse is 'true'
-#  # use version number from solution xml for pipeline build number
-#  # Updating the Pipeline Build number is only useful for display purposes
-#- pwsh: |
-#    $solutionXMLPath = "$(Build.SourcesDirectory)\$(RepoName)\${{parameters.solutionName}}\SolutionPackage\src\Other\Solution.xml"
-#    [xml]$solutionXmlDoc = Get-Content -LiteralPath $solutionXMLPath
-#    Write-Host "##vso[build.updatebuildnumber]$($solutionXmlDoc.ImportExportXml.SolutionManifest.Version)"
-#  displayName: 'Update Build Number from Solution XML'
-#  condition: and(succeeded(), eq(variables.UseSolutionVersionFromDataverse, 'true'))
+  # If UseSolutionVersionFromDataverse is 'true'
+  # use version number from solution xml for pipeline build number
+  # Updating the Pipeline Build number is only useful for display purposes
+- pwsh: |
+    $solutionXMLPath = "$(Build.SourcesDirectory)\$(RepoName)\${{parameters.solutionName}}\SolutionPackage\src\Other\Solution.xml"
+    [xml]$solutionXmlDoc = Get-Content -LiteralPath $solutionXMLPath
+    Write-Host "##vso[build.updatebuildnumber]$($solutionXmlDoc.ImportExportXml.SolutionManifest.UniqueName), v$($solutionXmlDoc.ImportExportXml.SolutionManifest.Version)"
+  displayName: 'Update Build Number from Solution XML'
+  condition: and(succeeded(), eq(variables.UseSolutionVersionFromDataverse, 'true'))
 
 
 # Before we committed changes, we formatted all json files for readability in source control.  This breaks solution package, so we need to flatten them before packing   

--- a/PowerShell/code-first-functions.ps1
+++ b/PowerShell/code-first-functions.ps1
@@ -411,6 +411,9 @@ function append-version-to-solutions{
         [Parameter(Mandatory)] [String]$solutionName,
         [Parameter(Mandatory)] [String]$buildNumber
     )
+    # If the Build number includes the solution name (e.g. when override variable UseSolutionVersionFromDataverse is true)
+    # strip the solution name from the Build number
+    $buildNumber = $buildNumber.Trim().TrimStart("$solutionName, ").TrimStart()
     $folderType = ".zip"
     $managedSolutionPath = "$artifactStagingDirectory\$solutionName" + "_managed.zip"
     $newManagedSolutionFileName = "$solutionName" + "_" + "$buildNumber" + "_" + "managed" + "$folderType"


### PR DESCRIPTION
In my previous PR https://github.com/microsoft/coe-alm-accelerator-templates/pull/228 i added a step that updates the Build number for the running pipeline based on the Solution XML version if the override variable `UseSolutionVersionFromDataverse` is `true`. While that is useful, the output in non-deployment pipelines (e.g. Import Unmanaged Solution) which uses the solution name as a template parameter now becomes a little confusing, since Import Unmanaged Solution now only shows `1.0.0.0` is the pipeline run name.

I have updated the step to also include the solution unique name together with the version. Now the example given above for Import Unmanaged Solution would read `MyFancySolution, v1.0.0.0` instead.