### PR TITLE
Fix update deployment settings if exactly one eligable deployment configuration

### DIFF
--- a/PowerShell/update-deployment-settings.ps1
+++ b/PowerShell/update-deployment-settings.ps1
@@ -308,7 +308,9 @@ function New-DeploymentPipelines
         $buildDefinitionResponseResults = $fullBuildDefinitionResponse.value
         Write-Host "Retrieved " $buildDefinitionResponseResults.length " builds"
 
-        $deploymentConfigurationData = $configurationData | Where-Object -FilterScript { [string]::IsNullOrWhiteSpace($_.StepType) -or $_.StepType -ne 809060000 }
+        [System.Object[]]$deploymentConfigurationData = $configurationData | Where-Object { 
+            ([string]::IsNullOrWhiteSpace($_.StepType)) -or ($_.StepType -ne 809060000)
+        }
         Write-Host "Retrieved " $deploymentConfigurationData.length " deployment configurations"
 
         if($branchResourceResults.length -eq 0 -or $buildDefinitionResponseResults.length -lt $deploymentConfigurationData.length) {


### PR DESCRIPTION
There is a bug in Update Deployment Settings in situations where you only have one (eligable) deployment configuration. In PowerShell the `Where-Object` commandlet will actually return the single instance from a collection if there is only one match. Because of that if only one element is returned the variable is a single object instance, not an array and thus the `length` property is undefined.

Coercing the return from `Where-Object` into an array fixes the issue.