### PR TITLE
'Group Teams' validation if AAD group already mapped to dataverse team

### DIFF
--- a/Pipelines/Templates/build-Solution.yml
+++ b/Pipelines/Templates/build-Solution.yml
@@ -71,25 +71,33 @@ steps:
       . "$env:POWERSHELLPATH/code-first-functions.ps1"
       restructure-legacy-folders '$(Build.ArtifactStagingDirectory)' '$(Build.SourcesDirectory)' '$(RepoName)' '${{parameters.solutionName}}' '$(pacPath)' '${{parameters.serviceConnectionUrl}}' '$(Agent.BuildDirectory)'
   displayName: 'Restructure legacy folders'
-  
-  # By default variable UseSolutionVersionFromDataverse is not 'true'
-  # use pipeline build number for versioning
+
+ # Solution version in source control is not used.  Instead, create version at build time from the current build number.
 - pwsh: |
    $solutionXMLPath = "$(Build.SourcesDirectory)\$(RepoName)\${{parameters.solutionName}}\SolutionPackage\src\Other\Solution.xml"
     . "$env:POWERSHELLPATH/build-deploy-solution-functions.ps1"
    update-solution-xml-with-build-number "$solutionXMLPath" "$(Build.BuildNumber)"
   displayName: 'Update Solution XML with Build Number'
-  condition: and(succeeded(), ne(variables.UseSolutionVersionFromDataverse, 'true'))
+  condition: and(succeeded(), ne('${{parameters.buildType}}', 'Unmanaged'))
+  
+#  # By default variable UseSolutionVersionFromDataverse is not 'true'
+#  # use pipeline build number for versioning
+#- pwsh: |
+#   $solutionXMLPath = "$(Build.SourcesDirectory)\$(RepoName)\${{parameters.solutionName}}\SolutionPackage\src\Other\Solution.xml"
+#    . "$env:POWERSHELLPATH/build-deploy-solution-functions.ps1"
+#   update-solution-xml-with-build-number "$solutionXMLPath" "$(Build.BuildNumber)"
+#  displayName: 'Update Solution XML with Build Number'
+#  condition: and(succeeded(), ne(variables.UseSolutionVersionFromDataverse, 'true'))
 
-  # If UseSolutionVersionFromDataverse is 'true'
-  # use version number from solution xml for pipeline build number
-  # Updating the Pipeline Build number is only useful for display purposes
-- pwsh: |
-    $solutionXMLPath = "$(Build.SourcesDirectory)\$(RepoName)\${{parameters.solutionName}}\SolutionPackage\src\Other\Solution.xml"
-    [xml]$solutionXmlDoc = Get-Content -LiteralPath $solutionXMLPath
-    Write-Host "##vso[build.updatebuildnumber]$($solutionXmlDoc.ImportExportXml.SolutionManifest.Version)"
-  displayName: 'Update Build Number from Solution XML'
-  condition: and(succeeded(), eq(variables.UseSolutionVersionFromDataverse, 'true'))
+#  # If UseSolutionVersionFromDataverse is 'true'
+#  # use version number from solution xml for pipeline build number
+#  # Updating the Pipeline Build number is only useful for display purposes
+#- pwsh: |
+#    $solutionXMLPath = "$(Build.SourcesDirectory)\$(RepoName)\${{parameters.solutionName}}\SolutionPackage\src\Other\Solution.xml"
+#    [xml]$solutionXmlDoc = Get-Content -LiteralPath $solutionXMLPath
+#    Write-Host "##vso[build.updatebuildnumber]$($solutionXmlDoc.ImportExportXml.SolutionManifest.Version)"
+#  displayName: 'Update Build Number from Solution XML'
+#  condition: and(succeeded(), eq(variables.UseSolutionVersionFromDataverse, 'true'))
 
 
 # Before we committed changes, we formatted all json files for readability in source control.  This breaks solution package, so we need to flatten them before packing   


### PR DESCRIPTION
Added validation while creating 'Group Teams'
- Check if any Dataverse team with AAD security group already exists

Fixes microsoft/coe-starter-kit#4076