### PR TITLE
Remove impersonation when updating component ownership

### DIFF
--- a/PowerShell/update-solution-component-owner.ps1
+++ b/PowerShell/update-solution-component-owner.ps1
@@ -11,7 +11,6 @@ function Invoke-UpdateSolutionComponentOwner {
         Import-Module $microsoftXrmDataPowerShellModule -Force -RequiredVersion $xrmDataPowerShellVersion -ArgumentList @{ NonInteractive = $true }
 
         $conn = Get-CrmConnection -ConnectionString "$dataverseConnectionString"
-        $impersonationConn = Get-CrmConnection -ConnectionString "$dataverseConnectionString"
 
         $flowsToSetOwners = [System.Collections.ArrayList]@()
         Get-OwnerFlowActivations $solutionComponentOwnershipConfiguration "" $conn $flowsToSetOwners
@@ -20,10 +19,9 @@ function Invoke-UpdateSolutionComponentOwner {
             #Need to deactivate the flow before setting ownership if currently active
             if ($ownershipConfig.solutionComponent.statecode_Property.Value -ne 0) {
                 Write-Host "Deactivating the Flow"
-                Set-CrmRecordState -conn $impersonationConn -EntityLogicalName workflow -Id $ownershipConfig.solutionComponentUniqueName -StateCode 0 -StatusCode 1
+                Set-CrmRecordState -conn $conn -EntityLogicalName workflow -Id $ownershipConfig.solutionComponentUniqueName -StateCode 0 -StatusCode 1
             }
             Write-Host "Setting flow owner: "$ownershipConfig.solutionComponent.name
-            $impersonationConn.OrganizationWebProxyClient.CallerId = $ownershipConfig.impersonationCallerId
             Set-CrmRecordOwner -conn $conn $ownershipConfig.solutionComponent $ownershipConfig.impersonationCallerId
         }
     }


### PR DESCRIPTION
There is a bug in the script that updates the solution component ownership according to deployment configuration after solution import.

Updating the component ownership should never occur in the context of the owning user (that user might not have appropriate access rights), but should always happen in the context of the importing user.

The common case would be that the importing user has extensive access rights in the environment (it needs to be able to import a solution after all), while the final owning user might be a user that has very access rights (you don't actually need a lot of access to actually own e.g. a flow).