### PR TITLE
Fix for space in project name

### DIFF
--- a/Pipelines/Templates/update-deployment-settings.yml
+++ b/Pipelines/Templates/update-deployment-settings.yml
@@ -38,8 +38,8 @@ steps:
 
       #Use the parsed value from the repo uri if it follows the expected format
       if ($segments.Length -gt 2) {
-        $pipelineProject = $segments[0]
-        $pipelineRepo = $segments[2]
+        $pipelineProject = [uri]::UnescapeDataString($segments[0])
+        $pipelineRepo = [uri]::UnescapeDataString($segments[2])
       }
 
       #Finally, use the override variables to bypass the options above


### PR DESCRIPTION
Fixes microsoft/coe-starter-kit#4077
Need to decode the values pulled from $(Build.Repository.Uri)