### PR TITLE
Handling 'Blank' spaces in 'Environment Variable' value reading logic

### DIFF
--- a/PowerShell/activate-flows.ps1
+++ b/PowerShell/activate-flows.ps1
@@ -319,8 +319,7 @@ function Get-OwnerFlowActivations {
                             $systemUserId = $systemuserResult.CrmRecords[0].systemuserid
                             #Activate the workflow using the owner.
                             $sortOrder = [int]::MaxValue
-                            #$activateFlow = 'true'
-                            $activateFlow = 'false'
+                            $activateFlow = 'true'
                             if ($null -ne $activationConfigs) {
                                 Write-Host "Retrieving activation config"
                                 $activationConfig = $activationConfigs | Where-Object { $_.solutionComponentUniqueName -eq $solutionComponent.objectid } | Select-Object -First 1

--- a/PowerShell/update-deployment-settings.ps1
+++ b/PowerShell/update-deployment-settings.ps1
@@ -100,7 +100,9 @@
                     }
                     #Set environment variable variables
                     elseif($configurationVariableName.StartsWith("environmentvariable.", "CurrentCultureIgnoreCase")) {
-                        $configurationVariableValue = $configurationVariableValue.Trim()
+                        if(-not [string]::IsNullOrEmpty($configurationVariableValue)) {
+                            $configurationVariableValue = $configurationVariableValue.Trim()
+                        }
                         Write-Host "configurationVariableValue - $configurationVariableValue"
                         if(-not [string]::IsNullOrEmpty($configurationVariableValue))
                         {

--- a/PowerShell/update-deployment-settings.ps1
+++ b/PowerShell/update-deployment-settings.ps1
@@ -100,11 +100,8 @@
                     }
                     #Set environment variable variables
                     elseif($configurationVariableName.StartsWith("environmentvariable.", "CurrentCultureIgnoreCase")) {
-                        if(-not [string]::IsNullOrEmpty($configurationVariableValue)) {
-                            $configurationVariableValue = $configurationVariableValue.Trim()
-                        }
                         Write-Host "configurationVariableValue - $configurationVariableValue"
-                        if(-not [string]::IsNullOrEmpty($configurationVariableValue))
+                        if(-not [string]::IsNullOrWhiteSpace($configurationVariableValue))
                         {
                             $schemaName = $configurationVariableName -replace "environmentvariable.", ""
                             $envVarResults =  Get-CrmRecords -conn $conn -EntityLogicalName environmentvariabledefinition -FilterAttribute "schemaname" -FilterOperator "eq" -FilterValue $schemaName -Fields type

--- a/PowerShell/update-deployment-settings.ps1
+++ b/PowerShell/update-deployment-settings.ps1
@@ -100,17 +100,24 @@
                     }
                     #Set environment variable variables
                     elseif($configurationVariableName.StartsWith("environmentvariable.", "CurrentCultureIgnoreCase")) {
-                        $schemaName = $configurationVariableName -replace "environmentvariable.", ""
-                        $envVarResults =  Get-CrmRecords -conn $conn -EntityLogicalName environmentvariabledefinition -FilterAttribute "schemaname" -FilterOperator "eq" -FilterValue $schemaName -Fields type
-                        if ($envVarResults.Count -gt 0){
-                            $type = $envVarResults.CrmRecords[0].type_Property.Value.Value
-                            if(-not [string]::IsNullOrEmpty($configurationVariableValue)) {
+                        $configurationVariableValue = $configurationVariableValue.Trim()
+                        Write-Host "configurationVariableValue - $configurationVariableValue"
+                        if(-not [string]::IsNullOrEmpty($configurationVariableValue))
+                        {
+                            $schemaName = $configurationVariableName -replace "environmentvariable.", ""
+                            $envVarResults =  Get-CrmRecords -conn $conn -EntityLogicalName environmentvariabledefinition -FilterAttribute "schemaname" -FilterOperator "eq" -FilterValue $schemaName -Fields type
+                            if ($envVarResults.Count -gt 0){
+                                $type = $envVarResults.CrmRecords[0].type_Property.Value.Value
+                                Write-Host "configurationVariableValue is not null or empty - $configurationVariableValue"
                                 $envVar = [PSCustomObject]@{"SchemaName"="$schemaName"; "Value"="#{$configurationVariableName}#"}
                                 if($usePlaceholders.ToLower() -eq 'false') {
                                     $envVar = [PSCustomObject]@{"SchemaName"="$schemaName"; "Value"="$configurationVariableValue"}
                                 }
-                                $environmentVariables.Add($envVar)
+                                $environmentVariables.Add($envVar)                                
                             }
+                        }
+                        else{
+                            Write-Host "Environment variable $configurationVariableName is Null or Empty"
                         }
                     }
                     elseif($configurationVariableName.StartsWith("canvasshare.aadGroupId.", "CurrentCultureIgnoreCase")) {


### PR DESCRIPTION
Handling 'Blank' spaces in 'Environment Variable' value reading logic.

Fixes microsoft/coe-starter-kit#4477
Fixes microsoft/coe-starter-kit#4328