### PR TITLE
removing pages projects,  improved error handling

### DIFF
--- a/Pipelines/Templates/export-Power-Page.yml
+++ b/Pipelines/Templates/export-Power-Page.yml
@@ -26,12 +26,12 @@ steps:
   displayName: "Fetch Portal Website Name"
   condition: and(succeeded(), ne(variables['websiteId'], 'NA'))
 
-##TODO Because the override flag is not exposed yet in tools, so we need to clear the folder manually
-#- pwsh: |
-#    . "$env:POWERSHELLPATH/portal-functions.ps1"
-#    Clean-Website-Folder "$(Build.SourcesDirectory)" "${{parameters.repo}}" "${{parameters.solutionName}}" "$(WebsiteName)"
-#  displayName: 'Clear Download Folder'
-#  condition: and(succeeded(), ne(variables['websiteId'], 'NA'))
+# Remove the existing website folder in case websiteId is "NA"
+- pwsh: |
+    . "$env:POWERSHELLPATH/portal-functions.ps1"
+    Clean-Website-Folder "$(Build.SourcesDirectory)" "${{parameters.repo}}" "${{parameters.solutionName}}"
+  displayName: 'Clear Download Folder'
+  condition: and(succeeded(), eq(variables['websiteId'], 'NA'))
 
 - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.download-paportal.PowerPlatformDownloadPaportal@2
   displayName: 'Export Power Page ${{parameters.solutionName}} from ${{parameters.serviceConnectionUrl}}'

--- a/Pipelines/Templates/update-canvas-app-ownership.yml
+++ b/Pipelines/Templates/update-canvas-app-ownership.yml
@@ -6,5 +6,12 @@ steps:
 # TEMPORARY WORKAROUND: Currently Canvas Apps cannot be owned by an app user, so we have to set an interactive user owner.  
 - powershell: |
     . "$env:POWERSHELLPATH/canvas-unpack-pack.ps1"
-     Update-Canvas-App-Ownership "$(CoETools_Microsoft_PowerApps_Administration_PowerShell)" "$(PowerAppsAdminModuleVersion)" "$(connectionVariables.BuildTools.TenantId)" "$(connectionVariables.BuildTools.ApplicationId)" "$(connectionVariables.BuildTools.ClientSecret)" "$(CoeTools_Microsoft_Xrm_Data_Powershell)" "$(XrmDataPowerShellVersion)" "$(connectionVariables.BuildTools.DataverseConnectionString)" "$(BuildTools.EnvironmentId)" "$(Build.RequestedForEmail)" "${{parameters.solutionName}}"
+    try {
+        Update-Canvas-App-Ownership "$(CoETools_Microsoft_PowerApps_Administration_PowerShell)" "$(PowerAppsAdminModuleVersion)" "$(connectionVariables.BuildTools.TenantId)" "$(connectionVariables.BuildTools.ApplicationId)" "$(connectionVariables.BuildTools.ClientSecret)" "$(CoeTools_Microsoft_Xrm_Data_Powershell)" "$(XrmDataPowerShellVersion)" "$(connectionVariables.BuildTools.DataverseConnectionString)" "$(BuildTools.EnvironmentId)" "$(Build.RequestedForEmail)" "${{parameters.solutionName}}"
+    } catch {
+        Write-Host "##vso[task.logissue type=warning]Errors occurred while updating App ownership. Please review the log for specific errors and verify your deployment configuration settings."
+        Write-Host $_
+        exit 1;
+    }
+
   displayName: 'Update Canvas App Ownership'

--- a/Pipelines/Templates/update-solution-component-ownership.yml
+++ b/Pipelines/Templates/update-solution-component-ownership.yml
@@ -9,7 +9,13 @@ steps:
     # load PowerShell files into memory
     . "$env:POWERSHELLPATH/activate-flows.ps1"
     . "$env:POWERSHELLPATH/update-solution-component-owner.ps1"
-    Invoke-UpdateSolutionComponentOwner '$(connectionVariables.BuildTools.DataverseConnectionString)' '${{parameters.serviceConnection}}' '$(CoETools_Microsoft_Xrm_Data_PowerShell)' '$(XrmDataPowerShellVersion)' '${{parameters.solutionComponentOwnershipConfiguration}}'
+    try {
+        Invoke-UpdateSolutionComponentOwner '$(connectionVariables.BuildTools.DataverseConnectionString)' '${{parameters.serviceConnection}}' '$(CoETools_Microsoft_Xrm_Data_PowerShell)' '$(XrmDataPowerShellVersion)' '${{parameters.solutionComponentOwnershipConfiguration}}'
+    } catch {
+        Write-Host "##vso[task.logissue type=warning]Errors occurred while updating solution component ownership. Please review the log for specific errors and verify your deployment configuration settings."
+        Write-Host $_
+        exit 1;
+    }
   displayName: 'Update Solution Component Ownwership'
   condition: and(succeeded(), not(contains(variables['outSolutionComponentOwnershipConfiguration'], '$(')))
   #condition: and(succeeded(), not(contains('${{parameters.solutionComponentOwnershipConfiguration}}', '$(')))

--- a/PowerShell/portal-functions.ps1
+++ b/PowerShell/portal-functions.ps1
@@ -54,10 +54,9 @@ function Clean-Website-Folder
     param (
         [Parameter(Mandatory)] [String]$sourcesDirectory,
         [Parameter(Mandatory)] [String]$repo,
-        [Parameter(Mandatory)] [String]$solutionName,        
-        [Parameter(Mandatory)] [String]$websiteName
+        [Parameter(Mandatory)] [String]$solutionName     
     )
-    $portalWebsitePath = "$sourcesDirectory\$repo\$solutionName\PowerPages\$websiteName\"
+    $portalWebsitePath = "$sourcesDirectory\$repo\$solutionName\PowerPages\"
     if(Test-Path "$portalWebsitePath"){
       Remove-Item "$portalWebsitePath\*" -Recurse -Force
     }


### PR DESCRIPTION
Updates based on testing. Power Pages are not removed in source control when the option to not source control is turned off after committing with it turned on. Additionally, we've had reports of errors that are being swallowed without communicating any warning or error in the pipeline. Adding additional error handling to report warnings when partial failures occur