### PR TITLE
Environment approval logic during Deployments.

### DIFF
--- a/Pipelines/Templates/build-deploy-Solution-To-Environment.yml
+++ b/Pipelines/Templates/build-deploy-Solution-To-Environment.yml
@@ -3,6 +3,42 @@
 # -Deploying the solution to a specific environment based on pipeline variables
 # This is most commonly used for PR Validation where both the build and deploy must suceeed in order for the PR checks to succeed.
 stages:
+- stage: build_and_deploy_pr_approval
+  displayName: 'Build and Deploy using PR Approval' 
+  condition: or(eq(variables['Build.Reason'], 'PullRequest'), ne(variables.ApprovalType,'Environment')) 
+  jobs:
+  - job: build_and_deploy_job
+
+    pool: 
+      vmImage: 'windows-2022'
+    steps:
+    - template: build-unmanaged-managed-Solution.yml
+
+    # If ImportUnmanaged variable passed in pipeline; Pass 'importUnmanaged' param to deploy-Solution.yml
+    - pwsh: |
+        $isunmanaged = 'false'
+        if('$(ImportUnmanaged)'.Contains("ImportUnmanaged")) {
+            write-Host "ImportUnmanaged variable is not passed"
+        }
+        else {
+            if('$(ImportUnmanaged)' -eq 'true'){
+                Write-Host "ImportUnmanaged is passed - " $(ImportUnmanaged)
+                $isunmanaged = 'true'
+            }
+        }
+
+        Write-Host "##vso[task.setVariable variable=IsUnmanaged]$isunmanaged"
+      displayName: "Set IsUnmanaged parameter"
+
+    - template: deploy-Solution.yml
+      parameters:
+        serviceConnectionName: $(ServiceConnection)
+        serviceConnectionUrl: $(ServiceConnectionUrl)
+        solutionName: $(SolutionName)
+        environmentName: $(EnvironmentName)
+        skipBuildToolsInstaller: 'true'
+        importUnmanaged: $(IsUnmanaged)
+        
 - stage: build_and_deploy_environment_approval
   displayName: 'Build and Deploy using Environment Approval' 
   condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables.ApprovalType,'Environment'))
@@ -42,39 +78,3 @@ stages:
                 environmentName: $(EnvironmentName)
                 skipBuildToolsInstaller: 'true'
                 importUnmanaged: $(IsUnmanaged)
-
-- stage: build_and_deploy_pr_approval
-  displayName: 'Build and Deploy using PR Approval' 
-  condition: or(eq(variables['Build.Reason'], 'PullRequest'), ne(variables.ApprovalType,'Environment')) 
-  jobs:
-  - job: build_and_deploy_job
-
-    pool: 
-      vmImage: 'windows-2022'
-    steps:
-    - template: build-unmanaged-managed-Solution.yml
-
-    # If ImportUnmanaged variable passed in pipeline; Pass 'importUnmanaged' param to deploy-Solution.yml
-    - pwsh: |
-        $isunmanaged = 'false'
-        if('$(ImportUnmanaged)'.Contains("ImportUnmanaged")) {
-            write-Host "ImportUnmanaged variable is not passed"
-        }
-        else {
-            if('$(ImportUnmanaged)' -eq 'true'){
-                Write-Host "ImportUnmanaged is passed - " $(ImportUnmanaged)
-                $isunmanaged = 'true'
-            }
-        }
-
-        Write-Host "##vso[task.setVariable variable=IsUnmanaged]$isunmanaged"
-      displayName: "Set IsUnmanaged parameter"
-
-    - template: deploy-Solution.yml
-      parameters:
-        serviceConnectionName: $(ServiceConnection)
-        serviceConnectionUrl: $(ServiceConnectionUrl)
-        solutionName: $(SolutionName)
-        environmentName: $(EnvironmentName)
-        skipBuildToolsInstaller: 'true'
-        importUnmanaged: $(IsUnmanaged)

--- a/Pipelines/Templates/build-deploy-Solution-To-Environment.yml
+++ b/Pipelines/Templates/build-deploy-Solution-To-Environment.yml
@@ -3,14 +3,55 @@
 # -Deploying the solution to a specific environment based on pipeline variables
 # This is most commonly used for PR Validation where both the build and deploy must suceeed in order for the PR checks to succeed.
 stages:
-- stage: build_and_deploy
-  displayName: 'Build and Deploy' 
+- stage: build_and_deploy_environment_approval
+  displayName: 'Build and Deploy using Environment Approval' 
+  condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables.ApprovalType,'Environment'))
   jobs:
   - job: build_and_deploy_job
+  - deployment: 
+    pool: 
+      vmImage: 'windows-2022'
+    environment: '$(EnvironmentName)'
+    strategy:
+      runOnce:
+        deploy:
+            steps:
+            - template: build-unmanaged-managed-Solution.yml
+
+            # If ImportUnmanaged variable passed in pipeline; Pass 'importUnmanaged' param to deploy-Solution.yml
+            - pwsh: |
+                $isunmanaged = 'false'
+                if('$(ImportUnmanaged)'.Contains("ImportUnmanaged")) {
+                    write-Host "ImportUnmanaged variable is not passed"
+                }
+                else {
+                    if('$(ImportUnmanaged)' -eq 'true'){
+                        Write-Host "ImportUnmanaged is passed - " $(ImportUnmanaged)
+                        $isunmanaged = 'true'
+                    }
+                }
+
+                Write-Host "##vso[task.setVariable variable=IsUnmanaged]$isunmanaged"
+              displayName: "Set IsUnmanaged parameter"
+
+            - template: deploy-Solution.yml
+              parameters:
+                serviceConnectionName: $(ServiceConnection)
+                serviceConnectionUrl: $(ServiceConnectionUrl)
+                solutionName: $(SolutionName)
+                environmentName: $(EnvironmentName)
+                skipBuildToolsInstaller: 'true'
+                importUnmanaged: $(IsUnmanaged)
+
+- stage: build_and_deploy_pr_approval
+  displayName: 'Build and Deploy using PR Approval' 
+  condition: or(eq(variables['Build.Reason'], 'PullRequest'), ne(variables.ApprovalType,'Environment')) 
+  jobs:
+  - job: build_and_deploy_job
+
     pool: 
       vmImage: 'windows-2022'
     steps:
-      
     - template: build-unmanaged-managed-Solution.yml
 
     # If ImportUnmanaged variable passed in pipeline; Pass 'importUnmanaged' param to deploy-Solution.yml

--- a/PowerShell/update-deployment-settings.ps1
+++ b/PowerShell/update-deployment-settings.ps1
@@ -74,6 +74,27 @@
             }
         }		
 
+        if($null -ne $configurationDataEnvironment.ApprovalType) {         
+            $approvalType=$configurationDataEnvironment.ApprovalType
+            Write-Host "Adding ApprovalType - $approvalType as pipeline parameter"
+            if($null -ne $approvalType){
+                $approvalTypeLabel = $null
+                switch ($approvalType) {
+                    "809060000" {$approvalTypeLabel = "Pull Request"}
+                    "809060001" {$approvalTypeLabel = "Environment"}
+                    default {$approvalTypeLabel = "None"}
+                }
+
+                # Check "ApprovalType" pipeline parameter is already presented. 
+                $found = Check-Parameter "ApprovalType" $newBuildDefinitionVariables
+                # If not presented, add the Parameter to the Pipeline
+                if(!$found) { 
+                    $newBuildDefinitionVariables | Add-Member -MemberType NoteProperty -Name "ApprovalType" -Value @{value = ''}
+                }
+                $newBuildDefinitionVariables.ApprovalType.value = $approvalTypeLabel
+            }
+        }
+
         if($null -ne $configurationDataEnvironment -and $null -ne $configurationDataEnvironment.UserSettings) {
             foreach($configurationVariable in $configurationDataEnvironment.UserSettings) {
                 $configurationVariableName = $configurationVariable.Name


### PR DESCRIPTION
Fixes microsoft\coe-starter-kit#4326

Implemented following logic:
- Pipelines will have an 'ApprovalType' variable with values read from 'Approval Type' column of 'Deployment Step'.
- If 'ApprovalType' is 'Environment' and Deployment is not a 'Pull Request', you need 'Environment' approval to complete deployment.
- If 'ApprovalType' is not 'Environment' a Pull Request gets created.