### PR TITLE
Capability to upload 'Portal User Settings' file from ALMAccelerator Canvas App

### DIFF
--- a/Pipelines/Templates/export-Power-Page.yml
+++ b/Pipelines/Templates/export-Power-Page.yml
@@ -49,10 +49,14 @@ steps:
 # Logic to read and set deployment profiles yml files under .\PowerPages\Websitename\deployment-profiles
 - pwsh: |
     . "$env:POWERSHELLPATH/portal-functions.ps1"
+    . "$env:POWERSHELLPATH/dataverse-webapi-functions.ps1"
     $websiteName = Get-Website-Name "$(Build.SourcesDirectory)" "${{parameters.repo}}" "${{parameters.solutionName}}"
     Write-Host "websiteName - $websiteName"
     . "$env:POWERSHELLPATH/update-deployment-settings.ps1"
     Set-PortalSettings-Files "$(Build.SourcesDirectory)" "${{parameters.repo}}" "${{parameters.serviceConnectionUrl}}" "${{parameters.solutionName}}" "$websiteName" "$env:MAPPED_SPN_Token"
+
+    #Read-File-Content "$env:MAPPED_SPN_Token" "$dataverseHost" "cat_portalsettingfile" "f56e384b-5ea1-ed11-aad1-000d3a32af20"
+
   env:
     DEPLOYMENT_SETTINGS: ${{parameters.configurationData}}
     MAPPED_SPN_Token: $(SpnToken)

--- a/Pipelines/Templates/export-Power-Page.yml
+++ b/Pipelines/Templates/export-Power-Page.yml
@@ -13,6 +13,8 @@ parameters:
   type: string
 - name: websiteName
   type: string
+- name: configurationData
+  type: string
 
 steps:
 # ALM Accelerator currently supports ALM of single website.
@@ -42,4 +44,17 @@ steps:
     DownloadPath: '$(Build.SourcesDirectory)\${{parameters.repo}}\${{parameters.solutionName}}\PowerPages\'
     WebsiteId: ${{parameters.websiteId}}
     Overwrite: true
+  condition: and(succeeded(), ne(variables['websiteId'], 'NA'))
+
+# Logic to read and set deployment profiles yml files under .\PowerPages\Websitename\deployment-profiles
+- pwsh: |
+    . "$env:POWERSHELLPATH/portal-functions.ps1"
+    $websiteName = Get-Website-Name "$(Build.SourcesDirectory)" "${{parameters.repo}}" "${{parameters.solutionName}}"
+    Write-Host "websiteName - $websiteName"
+    . "$env:POWERSHELLPATH/update-deployment-settings.ps1"
+    Set-PortalSettings-Files "$(Build.SourcesDirectory)" "${{parameters.repo}}" "${{parameters.serviceConnectionUrl}}" "${{parameters.solutionName}}" "$websiteName" "$env:MAPPED_SPN_Token"
+  env:
+    DEPLOYMENT_SETTINGS: ${{parameters.configurationData}}
+    MAPPED_SPN_Token: $(SpnToken)
+  displayName: 'Fetch and set deployment profiles'
   condition: and(succeeded(), ne(variables['websiteId'], 'NA'))

--- a/Pipelines/Templates/export-Solution.yml
+++ b/Pipelines/Templates/export-Solution.yml
@@ -50,6 +50,9 @@ parameters:
 - name: publishCustomizations
   type: string
   default: 'true'
+- name: CommitScope
+  type: string
+  default: '1'
 steps:
 - template: set-service-connection-url.yml
   parameters:
@@ -285,6 +288,7 @@ steps:
     serviceConnectionName: '${{parameters.serviceConnectionName}}'
     solutionName: '${{parameters.solutionName}}'
     websiteName: '${{parameters.portalSiteName}}'
+    configurationData: '${{parameters.configurationData}}'
 
 - template: Hooks\export-power-page-post-hook.yml
 

--- a/Pipelines/export-solution-to-git.yml
+++ b/Pipelines/export-solution-to-git.yml
@@ -61,6 +61,9 @@ parameters:
 - name: PublishCustomizations
   type: string
   default: "true"
+- name: CommitScope
+  type: string
+  default: "1"
 trigger: none
 pr: none
 

--- a/PowerShell/portal-functions.ps1
+++ b/PowerShell/portal-functions.ps1
@@ -49,6 +49,29 @@ function Validate-Profile-Name
     return $filesCount
 }
 
+function Create-or-Override-Profile-File
+{
+    param (
+        [Parameter(Mandatory)] [String]$websiteRepoPath,
+        [Parameter(Mandatory)] [String]$passedProfileName,
+        [Parameter(Mandatory)] [String]$profileContent
+    )
+
+    $deploymentProfilePath = "$websiteRepoPath\deployment-profiles"
+
+    # Create deployment Profile Path
+    New-Item -ItemType Directory -Force -Path $deploymentProfilePath
+
+    if (!(Test-Path "$deploymentProfilePath\$passedProfileName.deployment.yml"))
+    {
+       New-Item -path "$deploymentProfilePath" -name "$passedProfileName.deployment.yml" -type "file" -value "$profileContent"
+       Write-Host "Created new yml file for $passedProfileName"
+    } else {
+      Set-Content -path "$deploymentProfilePath\$passedProfileName.deployment.yml" -value "$profileContent"
+      Write-Host "Overriden the Content of yml file for $passedProfileName"
+    }
+}
+
 function Clean-Website-Folder
 {
     param (


### PR DESCRIPTION
Fixes microsoft/coe-starter-kit#4752

Added a new File type column to 'User Settings' table.
User uploads the portal settings yml file from console app.
![image](https://user-images.githubusercontent.com/104883923/220330331-93219a45-79f5-43ed-ae95-fdc86e833f1a.png)
Cloud flow reads the file content and converts to plain text and saves to 'User Settings'.
Pipleines reads the portal config data and creates the files under .\PowerPages\Websitename\deployment-profiles