### PR TITLE
Handle spaces in cdsproj paths

### DIFF
--- a/PowerShell/code-first-functions.ps1
+++ b/PowerShell/code-first-functions.ps1
@@ -97,7 +97,7 @@ function Add-Codefirst-Projects-To-Cdsproj{
           foreach($pcfProj in $pcfProjectFiles)
           {     
             Write-Host "Adding Reference of Pcf Project - " $pcfProj.FullName
-            $pcfProjectPath = $pcfProj.FullName
+            $pcfProjectPath = "`"$($pcfProj.FullName)`""
 
             $addReferenceCommand = "solution add-reference --path $pcfProjectPath"
             Write-Host "Add Reference Command - $addReferenceCommand"


### PR DESCRIPTION
Escape the full path in order to handle spaces within the path name of PCF project references. Handles issue #5118