### PR TITLE
Configuration migration data before flow activation and CanViewWithShare option

### DIFF
--- a/Pipelines/Templates/deploy-Solution.yml
+++ b/Pipelines/Templates/deploy-Solution.yml
@@ -260,6 +260,11 @@ steps:
 
 - template: Hooks\deploy-solution-configure-pre-hook.yml
 
+- template: import-configuration-migration-data.yml
+  parameters:
+    serviceConnection: '${{parameters.serviceConnectionName}}'
+    environmentName: '${{parameters.environmentName}}'
+
 - template: set-dataverse-aad-group-teams.yml
   parameters:
     serviceConnection: '${{parameters.serviceConnectionUrl}}'
@@ -302,11 +307,6 @@ steps:
   parameters:
     serviceConnection: '${{parameters.serviceConnectionUrl}}'
     connectorShareWithGroupTeamConfiguration: '$(outConnectorShareWithGroupTeamConfiguration)'
-
-- template: import-configuration-migration-data.yml
-  parameters:
-    serviceConnection: '${{parameters.serviceConnectionName}}'
-    environmentName: '${{parameters.environmentName}}'
 
 - template: run-canvas-tests.yml 
   parameters:

--- a/PowerShell/canvas-unpack-pack.ps1
+++ b/PowerShell/canvas-unpack-pack.ps1
@@ -100,8 +100,11 @@ function Invoke-Share-Canvas-App-with-AAD-Group
                 $canvasApps = Get-CrmRecords -conn $conn -EntityLogicalName canvasapp -FilterAttribute "name" -FilterOperator "eq" -FilterValue $canvasNameInSolution -Fields canvasappid
                 if($canvasApps.Count -gt 0) {
                     $appId = $canvasApps.CrmRecords[0].canvasappid
-                    #$environmentId = "$environmentId"
                     Write-Host "Sharing app $appId with $aadGroupId"
+					# 'CanViewWithShare' is no longer works. Replacing with 'CanView'.
+                    if($roleName -eq "CanViewWithShare"){
+                        $roleName = "CanView"
+                    }
                     Set-AdminPowerAppRoleAssignment -PrincipalType Group -PrincipalObjectId $aadGroupId -RoleName $roleName -AppName $appId -EnvironmentName $environmentId
                 }
                 else {


### PR DESCRIPTION
Fixes microsoft/coe-starter-kit#4319
Fixes microsoft/coe-starter-kit#4345
Moved configuration migration data step next to solution Import.
Also, as the App's 'CanViewWithShare' is no longer works. Replacing with 'CanView'. Hidden 'CanViewWithShare' option from Canvas App.