### PR TITLE
Fix issue 5470

### DIFF
--- a/PowerShell/code-first-functions.ps1
+++ b/PowerShell/code-first-functions.ps1
@@ -138,7 +138,7 @@ function Add-Codefirst-Projects-To-Cdsproj{
                 $csProjectPath = "`"$($csProject.FullName)`""    
 
                 # Read csproj xml to determin project type
-                [xml]$xmlDoc = Get-Content -Path $csProjectPath
+                [xml]$xmlDoc = Get-Content -Path $csProject.FullName
                 $tagPowerAppsTargetsPath = $xmlDoc.Project.PropertyGroup.PowerAppsTargetsPath
 
                 # 'PowerAppsTargetsPath' tag is only availble in plugin project generate via 'pac plugin init'


### PR DESCRIPTION
Fixes microsoft/coe-starter-kit#5470
Don't use quoted path when getting csproj file contents