### PR TITLE
Null check for unique canvas app id

### DIFF
--- a/PowerShell/canvas-unpack-pack.ps1
+++ b/PowerShell/canvas-unpack-pack.ps1
@@ -110,14 +110,19 @@ function Invoke-Share-Canvas-App-with-AAD-Group
                     $appId = $canvasApps.CrmRecords[0].canvasappid
                     $uniqueCanvasAppId = $canvasApps.CrmRecords[0].uniquecanvasappid
                     Write-Host "AppId - $appId and UniqueCanvasAppId - $uniqueCanvasAppId"
-                    Write-Host "Sharing app using uniquecanvasappid - $uniqueCanvasAppId with AADGroup - $aadGroupId. Environment - $environmentName"
 
 					# 'CanViewWithShare' is no longer works. Replacing with 'CanView'.
                     if($roleName -eq "CanViewWithShare"){
                         $roleName = "CanView"
                     }
-                    Write-Host "Command - Set-AdminPowerAppRoleAssignment -PrincipalType Group -PrincipalObjectId $aadGroupId -RoleName $roleName -AppName $uniqueCanvasAppId -EnvironmentName $environmentId"
-                    Set-AdminPowerAppRoleAssignment -PrincipalType Group -PrincipalObjectId $aadGroupId -RoleName $roleName -AppName $uniqueCanvasAppId -EnvironmentName $environmentId
+                    if($null -ne $uniqueCanvasAppId) {
+                        Write-Host "Command Unique Id- Set-AdminPowerAppRoleAssignment -PrincipalType Group -PrincipalObjectId $aadGroupId -RoleName $roleName -AppName $uniqueCanvasAppId -EnvironmentName $environmentId"
+                        Set-AdminPowerAppRoleAssignment -PrincipalType Group -PrincipalObjectId $aadGroupId -RoleName $roleName -AppName $uniqueCanvasAppId -EnvironmentName $environmentId
+                    }
+                    else {
+                        Write-Host "Command App Id- Set-AdminPowerAppRoleAssignment -PrincipalType Group -PrincipalObjectId $aadGroupId -RoleName $roleName -AppName $appId -EnvironmentName $environmentId"
+                        Set-AdminPowerAppRoleAssignment -PrincipalType Group -PrincipalObjectId $aadGroupId -RoleName $roleName -AppName $appId -EnvironmentName $environmentId
+                    }
                 }
                 else {
                     Write-Host "##vso[task.logissue type=warning]A specified canvas app was not found in the target environment. Verify your deployment configuration and try again."


### PR DESCRIPTION
In some cases unique id may be null. We should check for null and revert back to canvasappid if it is.