### PR TITLE
Set 'Membership Type' to Team.

### DIFF
--- a/Pipelines/export-solution-to-git.yml
+++ b/Pipelines/export-solution-to-git.yml
@@ -65,6 +65,10 @@ parameters:
 - name: CommitScope
   type: string
   default: "1"
+- name: AgentPool
+  type: string
+- name: VMImage
+  type: string
 trigger: none
 pr: none
 

--- a/Pipelines/export-solution-to-git.yml
+++ b/Pipelines/export-solution-to-git.yml
@@ -67,8 +67,10 @@ parameters:
   default: "1"
 - name: AgentPool
   type: string
+  default: "Azure Pipelines"
 - name: VMImage
   type: string
+  default: "windows-latest"
 trigger: none
 pr: none
 


### PR DESCRIPTION
Fixes microsoft/coe-starter-kit#6050
Fixes microsoft/coe-starter-kit#6116

Set 'Membership Type' to Team.
Removed Team Name match logic while updating Teams.