### PR TITLE
Skip solution import (Update/Upgrade) during deployment

### DIFF
--- a/Pipelines/Templates/deploy-Solution.yml
+++ b/Pipelines/Templates/deploy-Solution.yml
@@ -134,7 +134,7 @@ steps:
     UseDeploymentSettingsFile: $(UseDeploymentSettings)
     DeploymentSettingsFile: $(DeploymentSettingsPath)
     MaxAsyncWaitTime: 120
-  condition: and(succeeded(), eq(variables['IsUnmanaged'], 'true'))
+  condition: and(succeeded(), ne(variables['SkipSolutionImport'],'true'), eq(variables['IsUnmanaged'], 'true'))
 
 - pwsh: |
    . "$env:POWERSHELLPATH/build-deploy-solution-functions.ps1"
@@ -145,7 +145,7 @@ steps:
         Write-Host "##vso[task.setVariable variable=TriggerSolutionUpgrade]false"
     }
   displayName: 'Get managed solution zip path'
-  condition: and(succeeded(), ne(variables['IsUnmanaged'], 'true'))
+  condition: and(succeeded(),ne(variables['SkipSolutionImport'],'true'), ne(variables['IsUnmanaged'], 'true'))
 
 # If the TriggerSolutionUpgrade variable is false, then import the solution as an Update
 - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.import-solution.PowerPlatformImportSolution@2
@@ -159,7 +159,7 @@ steps:
     UseDeploymentSettingsFile: $(UseDeploymentSettings)
     DeploymentSettingsFile: $(DeploymentSettingsPath)
     MaxAsyncWaitTime: 120
-  condition: and(succeeded(), ne(variables['IsUnmanaged'], 'true'), or(eq(variables['TriggerSolutionUpgrade'], 'false'), eq(variables['SolutionExists'], 'false')))
+  condition: and(succeeded(),ne(variables['SkipSolutionImport'],'true'), ne(variables['IsUnmanaged'], 'true'), or(eq(variables['TriggerSolutionUpgrade'], 'false'), eq(variables['SolutionExists'], 'false')))
 
 # If the TriggerSolutionUpgrade variable is true, then import the solution as an Upgrade, staging it as a holding solution, so we can apply a solution Upgrade.
 # Doing this will ensure that items removed from the solution in development are also removed from the solution in the target environment after the Upgrade is applied.
@@ -174,7 +174,7 @@ steps:
     UseDeploymentSettingsFile: $(UseDeploymentSettings)
     DeploymentSettingsFile: $(DeploymentSettingsPath)
     MaxAsyncWaitTime: 120
-  condition: and(succeeded(), ne(variables['IsUnmanaged'], 'true'), eq(variables['TriggerSolutionUpgrade'], 'true'), eq(variables['SolutionExists'], 'true'))
+  condition: and(succeeded(),ne(variables['SkipSolutionImport'],'true'), ne(variables['IsUnmanaged'], 'true'), eq(variables['TriggerSolutionUpgrade'], 'true'), eq(variables['SolutionExists'], 'true'))
 
 # NOTE: Sometimes you need to perform intermediary steps between staging the upgrade and applying it.  
 # An example would be moving data from one entity to another before deleting the entity.
@@ -187,14 +187,14 @@ steps:
     PowerPlatformSPN: '${{parameters.serviceConnectionName}}'
     SolutionName: ${{parameters.solutionName}}
     AsyncOperation: true
-  condition: and(succeeded(), eq(variables['TriggerSolutionUpgrade'], 'true'), eq(variables['SolutionExists'], 'true'))
+  condition: and(succeeded(),ne(variables['SkipSolutionImport'],'true'), eq(variables['TriggerSolutionUpgrade'], 'true'), eq(variables['SolutionExists'], 'true'))
 
 - task: microsoft-IsvExpTools.PowerPlatform-BuildTools.publish-customizations.PowerPlatformPublishCustomizations@2
   displayName: 'Power Platform Publish Customizations '
   inputs:
     authenticationType: PowerPlatformSPN
     PowerPlatformSPN: '${{parameters.serviceConnectionName}}'
-  condition: and(succeeded(), eq(variables['IsUnmanaged'], 'true'))
+  condition: and(succeeded(),ne(variables['SkipSolutionImport'],'true'), eq(variables['IsUnmanaged'], 'true'))
   # Only publish customizations for when importing unmanaged solutions into a dev environment.
 
 # Set deployment variables

--- a/PowerShell/brach-pipeline-policy.ps1
+++ b/PowerShell/brach-pipeline-policy.ps1
@@ -646,11 +646,11 @@ function Get-Repository-Build-Definitions {
         [Parameter(Mandatory)] [string]$solutionRepoId
     )
 
+    Write-Host "Inside Get-Repository-Build-Definitions"
     $buildDefinitionResponse = $null
     $uriBuildDefinition = "$orgUrl$buildProjectName/_apis/build/definitions?repositoryId=$solutionRepoId&repositoryType=TfsGit&api-version=6.0"
 
-    #$uriBuildDefinition = "$orgUrl$buildProjectName/_apis/build/definitions?api-version=6.0"
-    #Write-Host "UriBuildDefinition - $uriBuildDefinition"
+    Write-Host "UriBuildDefinition - $uriBuildDefinition"
     try {
         $buildDefinitionResponse = Invoke-RestMethod $uriBuildDefinition -Method Get -Headers @{
             Authorization = "$azdoAuthType  $env:SYSTEM_ACCESSTOKEN"
@@ -661,7 +661,7 @@ function Get-Repository-Build-Definitions {
         return
     }
 
-    #Write-Host "Build Definition Response - $buildDefinitionResponse"
+    Write-Host "Build Definition Response - $buildDefinitionResponse"
     return $buildDefinitionResponse
 }
 
@@ -747,9 +747,10 @@ function Set-Branch-Policy{
     # Check if a Policy Type by name 'Build' exists.
     $buildTypes = $policyTypes.value | Where-Object { $_.displayName -eq "Build" }
     if($buildTypes){
+        Write-Host "Policy Type by name 'Build' exists. Getting Policy configurations."
         # Get existing Policy configurations
         $uriPolicyConfigs = "$orgUrl$solutionProjectName/_apis/policy/configurations?api-version=6.0"
-        #Write-Host "UriPolicyConfigs - $uriPolicyConfigs"
+        Write-Host "UriPolicyConfigs - $uriPolicyConfigs"
         try {
             $policyConfigResponse = Invoke-RestMethod $uriPolicyConfigs -Method Get -Headers @{
                 Authorization = "$azdoAuthType  $env:SYSTEM_ACCESSTOKEN"
@@ -761,7 +762,7 @@ function Set-Branch-Policy{
         }
 
         $existingPolices = $null
-        #Write-Host "Policy Configuration Response - $policyConfigResponse"
+        Write-Host "Policy Configuration Response - $policyConfigResponse"
         # Loop through the policy configurations and output the results
         foreach ($policyConfig in $policyConfigResponse.value) {
             $refName = $($policyConfig.settings.Scope.refName)
@@ -788,7 +789,6 @@ function Set-Branch-Policy{
 
         Write-Host "Creating a new Policy."
         $builds = Get-Repository-Build-Definitions "$orgUrl" "$solutionProjectName" "$azdoAuthType" "$solutionRepoId"
-        #$builds = Get-Project-Build-Definitions "$orgUrl" "$solutionProjectName" "$azdoAuthType"
 
         $destinationBuild = $builds.value | Where-Object {$_.name -eq "deploy-validation-$solutionName"}
 
@@ -874,9 +874,10 @@ function Get-Policy-Types {
         [Parameter(Mandatory)] [string]$azdoAuthType
     )
 
+    Write-Host "Fetching policy types"
     $policyTypesResponse = $null    
-    $uriPolicyTypes = "$orgUrl$buildProjectName/_apis/policy/types?api-version=6.0-preview.1"
-    #Write-Host "UriPolicyTypes - $uriPolicyTypes"
+    $uriPolicyTypes = "$orgUrl$solutionProjectName/_apis/policy/types?api-version=6.0-preview.1"
+    Write-Host "UriPolicyTypes - $uriPolicyTypes"
     try {
         $policyTypesResponse = Invoke-RestMethod $uriPolicyTypes -Method Get -Headers @{
             Authorization = "$azdoAuthType  $env:SYSTEM_ACCESSTOKEN"
@@ -887,7 +888,7 @@ function Get-Policy-Types {
         return
     }
 
-    #Write-Host "Policy Types Response - $policyTypesResponse"
+    Write-Host "Policy Types Response - $policyTypesResponse"
     return $policyTypesResponse
 }
 


### PR DESCRIPTION
Solution import can be skipped by passing 'SkipSolutionImport' as true in the deployment pipelines.

Fixes microsoft/coe-starter-kit#6262

![image](https://github.com/microsoft/coe-alm-accelerator-templates/assets/104883923/5fa89000-6833-4a07-ad33-3f3e0098c088)

