### PR TITLE
Logic to handle multiple sharing in Flows and Custom connectors.

### DIFF
--- a/Pipelines/Templates/share-flows-with-group-team.yml
+++ b/Pipelines/Templates/share-flows-with-group-team.yml
@@ -19,8 +19,7 @@ steps:
             if($c.aadGroupTeamName -ne '' -and $c.solutionComponentUniqueName -ne '') {
                 Write-Host "Sharing flow - " $c.solutionComponentUniqueName " with " $c.aadGroupTeamName
                 try {
-                    Grant-AccessToWorkflow "$env:MAPPED_SPN_Token" "$dataverseHost" $c.aadGroupTeamName $c.solutionComponentUniqueName
-                    Write-Host "Grant-AccessToWorkflow executed successfully."
+                    Grant-AccessToWorkflow "$env:MAPPED_SPN_Token" "$dataverseHost" $c.aadGroupTeamName $c.solutionComponentUniqueName                    
                 } catch {
                     Write-Host "Grant-AccessToWorkflow execution failed - $($_.Exception.Message)"
                 }

--- a/PowerShell/export-solution-functions.ps1
+++ b/PowerShell/export-solution-functions.ps1
@@ -138,20 +138,39 @@ function Remove-Code-From-Custom-Connectors-Where-Disabled
    Write-Host $repo
    Write-Host $solutionName
    $connectorspath = "$buildSourceDirectory\$repo\$solutionName\SolutionPackage\src\Connectors";
-   Write-Host $connectorspath
+   Write-Host "Connectors Path - " $connectorspath
 
-   if(-not [string]::IsNullOrEmpty($connectorspath)) {
+   if (-not [string]::IsNullOrEmpty($connectorspath)) {
      Get-ChildItem -Path "$connectorspath" -Recurse -Filter *.xml | 
      ForEach-Object {
-       $xml = [xml](Get-Content $_.FullName)
-       $connectornode = $xml.SelectSingleNode("//Connector")
-       Write-Host $connectornode.OuterXml
-       $scriptoperationsnode = $connectornode.SelectSingleNode("//scriptoperations")
-       $customcodeblobcontentnode = $connectornode.SelectSingleNode("//customcodeblobcontent")
-       $connectornode.RemoveChild($scriptoperationsnode)
-       $connectornode.RemoveChild($customcodeblobcontentnode)
-       $xml.Save($_.FullName)
+       try {
+           $xml = [xml](Get-Content $_.FullName)
+           $connectornode = $xml.SelectSingleNode("//Connector")
+           if ($connectornode -ne $null) {
+               Write-Host $connectornode.OuterXml
+               $scriptoperationsnode = $connectornode.SelectSingleNode("//scriptoperations")
+               $customcodeblobcontentnode = $connectornode.SelectSingleNode("//customcodeblobcontent")
+               if ($scriptoperationsnode -ne $null) {
+                   Write-Host "Removing //scriptoperations"
+                   $connectornode.RemoveChild($scriptoperationsnode)
+               }
+               else{
+                  Write-Host "//scriptoperations node is blank"
+               }
+               if ($customcodeblobcontentnode -ne $null) {
+                   Write-Host "Removing //customcodeblobcontent"
+                   $connectornode.RemoveChild($customcodeblobcontentnode)
+               }
+               else{
+                  Write-Host "//customcodeblobcontent node is blank"
+               }
+
+               $xml.Save($_.FullName)
+           }
+       }
+       catch {
+           Write-Host "An error occurred while processing $_.FullName:`r`n$($_.Exception.Message)"
+       }
      }
    }
-	
 }

--- a/PowerShell/share-rows-with-group-team.ps1
+++ b/PowerShell/share-rows-with-group-team.ps1
@@ -9,14 +9,22 @@ function Grant-AccessToWorkflow {
         [Parameter(Mandatory)] [String]$teamName,
         [Parameter(Mandatory)] [String]$workflowId
     )
+        #Load util function
+    . "$env:POWERSHELLPATH/util.ps1"
+
     Write-Host "teamName - $teamName"
     Write-Host "workflowId - $workflowId"
+    $validatedId = Validate-And-Clean-Guid $workflowId
+    if (!$validatedId) {
+        Write-Host "Invalid  workflowId GUID. Exiting from Grant-AccessToWorkflow."
+        return
+    }
     $teamId = Get-TeamId $token $dataverseHost $teamName
     Write-Host "teamId - $teamId"
     if($teamId -ne '') {
         $body = "{
         `n    `"Target`":{
-        `n        `"workflowid`":`"$workflowId`",
+        `n        `"workflowid`":`"$validatedId`",
         `n        `"@odata.type`": `"Microsoft.Dynamics.CRM.workflow`"
         `n    },
         `n    `"PrincipalAccess`":{
@@ -43,11 +51,22 @@ function Grant-AccessToConnector {
         [Parameter(Mandatory)] [String]$teamName,
         [Parameter(Mandatory)] [String]$connectorId
     )
+        #Load util function
+    . "$env:POWERSHELLPATH/util.ps1"
+
+    Write-Host "TeamName - $teamName"
+    Write-Host "ConnectorId - $connectorId"   
+    $validatedId = Validate-And-Clean-Guid $connectorId
+    if (!$validatedId) {
+        Write-Host "Invalid  ConnectorId GUID. Exiting from Grant-AccessToConnector."
+        return
+    }
+
     $teamId = Get-TeamId $token $dataverseHost $teamName
     if($teamId -ne '') {
         $body = "{
         `n    `"Target`":{
-        `n        `"connectorid`":`"$connectorId`",
+        `n        `"connectorid`":`"$validatedId`",
         `n        `"@odata.type`": `"Microsoft.Dynamics.CRM.connector`"
         `n    },
         `n    `"PrincipalAccess`":{
@@ -58,7 +77,7 @@ function Grant-AccessToConnector {
         `n        `"AccessMask`": `"ReadAccess`"
         `n    }
         `n}"
-    
+
         $requestUrlRemainder = "GrantAccess"
         Invoke-DataverseHttpPost $token $dataverseHost $requestUrlRemainder $body
     }

--- a/PowerShell/util.ps1
+++ b/PowerShell/util.ps1
@@ -1,0 +1,107 @@
+<#
+This function returns an encoded text.
+#>
+function Get-Encoded-Text
+{
+    param (
+        [Parameter(Mandatory)] [String]$originalText
+    )
+
+    Write-Host "OriginalText - $originalText"
+    # Encode the text using Base64
+    $encodedBytes = [System.Text.Encoding]::UTF8.GetBytes($originalText)
+    $encodedText = [System.Convert]::ToBase64String($encodedBytes)
+
+    Write-Host "EncodedText - $encodedText"
+    return $encodedText
+}
+
+<#
+This function returns a decoded text.
+#>
+function Get-Decoded-Text
+{
+    param (
+        [Parameter(Mandatory)] [String]$encodedText
+    )
+
+    Write-Host "EncodedText - $encodedText"
+    # Decode the Base64 encoded text
+    $decodedBytes = [System.Convert]::FromBase64String($encodedText)
+    $decodedText = [System.Text.Encoding]::UTF8.GetString($decodedBytes)
+
+    Write-Host "DecodedText - $decodedText"
+    return $decodedText
+}
+
+<#
+This function checks if repetative 'Names' mentioned in 'UserSettings'.
+If yes, returns the index
+#>
+function Get-IndicesOfNodesWithValue {
+    param (
+        [string]$jsonString,
+        [string]$searchName,
+        [string]$searchValue
+    )
+
+    try {
+        Write-Host "Inside Get-IndicesOfNodesWithValue"
+        Write-Host "JsonString - $jsonString"
+        Write-Host "SearchName - $searchName"
+        Write-Host "SearchValue - $searchValue"
+        $jsonArray = ConvertFrom-Json $jsonString
+        $matchingIndex = -1
+
+        $nameMatches = @()
+
+        for ($i = 0; $i -lt $jsonArray.Count; $i++) {
+            if ($jsonArray[$i].Name -eq $searchName) {
+                $nameMatches += ($i + 1)
+            }
+        }
+
+        Write-Host "nameMatches count - $($nameMatches.Count)"
+        if ($nameMatches.Count -gt 1) {
+            for ($j = 0; $j -lt $nameMatches.Count; $j++) {
+                $index = $nameMatches[$j] - 1
+                Write-Host "jsonArray[index].Value - $($jsonArray[$index].Value)"
+                Write-Host "searchValue - $searchValue"
+                if ($jsonArray[$index].Value -eq $searchValue) {
+                    Write-Host "Matched found for SearchValue - $searchValue"
+                    $matchingIndex = ($j + 1)
+                    break
+                }
+            }
+        }
+
+        return $matchingIndex
+    }
+    catch {
+        Write-Host "Error parsing JSON: $_"
+        return -1
+    }
+}
+
+<#
+Sometimes GUID contains underscore (incase of multiple share with teams scenario).
+This function trims and validates the GUID.
+#>
+function Validate-And-Clean-Guid {
+    param (
+        [string]$inputGuid
+    )
+
+    try {
+        # Use a regular expression to match the GUID pattern
+        if ($inputGuid -match '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})') {
+            return $Matches[1]
+        } else {
+            Write-Host "Invalid GUID format: $inputGuid"
+            return $null
+        }
+    } catch {
+        Write-Host "An error occurred during GUID validation: $_"
+        return $null
+    }
+}


### PR DESCRIPTION
Fixes microsoft/coe-starter-kit#6367
Logic to handle multiple sharing in Flows and Custom connectors. 
Users who don't use 'ALM Accelerator for Power Platform' canvas app to commit their solutions, can now append underscore and numbers end of the component unique name.
![image](https://github.com/microsoft/coe-alm-accelerator-templates/assets/104883923/383744ed-05a6-4ff5-a433-6264b4cc38f5)

