### PR TITLE
chore: upgrade FileTransform@1 --> FileTransform@2

### DIFF
--- a/Pipelines/Templates/deploy-Solution.yml
+++ b/Pipelines/Templates/deploy-Solution.yml
@@ -93,7 +93,7 @@ steps:
     environmentName: '${{parameters.environmentName}}'
 
 # Update any deploymentSettings.json via FileTransform task. This task will replace values in a JSON file based on their path. See https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/transforms-variable-substitution?view=azure-devops&tabs=Classic#jsonvarsubs
-- task: FileTransform@1
+- task: FileTransform@2
   displayName: 'File Transformation: deploymentSettings.json'
   inputs:
     folderPath: '$(Pipeline.Workspace)'


### PR DESCRIPTION
This updates the FileTransform version from 1 to 2. Version 1 is deprecated and throws a warning in pipelines:

![image](https://github.com/user-attachments/assets/db1d1502-547c-40b0-8263-6c0b532eb346)

What's new in File Transform version 2:

- More optimized task fields that allow users to enable any/all of the transformation (XML), variable substitution (JSON and XML) features in a single task instance.
- Task fails when any of the configured transformation/substitution is NOT applied or when the task is no-op.

NOTE:
By default, the task will default to the same behavior as in task version 1 unless the following variable is set to TRUE:

```
{
    "name": "errorOnInvalidSubstitution",
    "type": "boolean",
    "label": "Error on empty files and invalid substitution.",
    "required": false,
    "defaultValue": false,
    "helpMarkDown": "If selected, the pipeline fails if the target files are empty or if the substitution fails."
}
```

When `errorOnInvalidSubstitution: true` is passed to the task, it will fail if no modifications are made to the JSON/XML or if the file does not exist.